### PR TITLE
[#16] 세션 마다 query db 커넥션을 생성하고 등록한다

### DIFF
--- a/be/src/app.module.ts
+++ b/be/src/app.module.ts
@@ -9,6 +9,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import dotenv from 'dotenv';
 import { SessionMiddleware } from './session/session.middleware';
 import { RedisModule } from './config/redis/redis.module';
+import { QueryDBModule } from './config/query-database/query-db.moudle';
 
 dotenv.config();
 
@@ -29,6 +30,7 @@ dotenv.config();
     ShellModule,
     QueryModule,
     RedisModule,
+    QueryDBModule,
   ],
 })
 export class AppModule {

--- a/be/src/config/query-database/query-db.adapter.ts
+++ b/be/src/config/query-database/query-db.adapter.ts
@@ -1,8 +1,8 @@
 import { Connection, RowDataPacket } from 'mysql2/promise';
 
 export interface QueryDBAdapter {
-  createConnection(identify: string): Promise<Connection>;
-  closeConnection(connection: Connection): void;
+  createConnection(identify: string): void;
+  getConnection(identify: string): Connection;
+  closeConnection(identify: string): void;
   run(connection: Connection, query: string): Promise<RowDataPacket[]>;
-  dropDatabase(key: string): void;
 }

--- a/be/src/config/query-database/single-mysql.adapter.ts
+++ b/be/src/config/query-database/single-mysql.adapter.ts
@@ -1,80 +1,74 @@
 import dotenv from 'dotenv';
 import { Injectable } from '@nestjs/common';
 import { QueryDBAdapter } from './query-db.adapter';
-import {
-  Connection,
-  createConnection,
-  createPool,
-  Pool,
-  RowDataPacket,
-} from 'mysql2/promise';
+import { Connection, createConnection, RowDataPacket } from 'mysql2/promise';
 
 dotenv.config();
 
 @Injectable()
 export class SingleMySQLAdapter implements QueryDBAdapter {
-  private pool: Pool;
+  private adminConnection: Connection;
+  private userConnectionList: Record<string, Connection> = {};
 
   constructor() {
-    this.createPool();
+    this.createAdminConnection();
   }
 
-  private createPool() {
-    this.pool = createPool({
+  private async createAdminConnection() {
+    this.adminConnection = await createConnection({
       host: process.env.QUERY_DB_HOST,
-      user: process.env.QUERY_DB_USERNAME,
+      user: process.env.QUERY_DB_USER,
       password: process.env.QUERY_DB_PASSWORD,
       port: parseInt(process.env.QUERY_DB_PORT || '3306', 10),
-      connectionLimit: 10,
     });
   }
 
   public async createConnection(identify: string) {
-    try {
-      const username = identify.substring(0, 10);
-      return await createConnection({
-        host: process.env.QUERY_DB_HOST,
-        user: username,
-        password: identify,
-        port: parseInt(process.env.QUERY_DB_PORT || '3306', 10),
-        database: identify,
-      });
-    } catch (e) {
-      //해당 database가 없을때
-      const username = identify.substring(0, 10);
+    const username = identify.substring(0, 10);
 
-      const createDatabase = `create database ${identify};`;
-      const createUser = `create user '${username}'@'%' identified by '${identify}';`;
-      const grantPrivilege = `grant all privileges on ${identify}.* to '${username}'@'%';`; // 사용자 db에 대해서만 권한 부여
-      await this.pool.execute(createDatabase);
-      await this.pool.execute(createUser);
-      await this.pool.execute(grantPrivilege);
+    const createDatabase = `create database ${identify};`;
+    const createUser = `create user '${username}'@'%' identified by '${identify}';`;
+    const grantPrivilege = `grant all privileges on ${identify}.* to '${username}'@'%';`; // 사용자 db에 대해서만 권한 부여
+    await this.adminConnection.execute(createDatabase);
+    await this.adminConnection.execute(createUser);
+    await this.adminConnection.execute(grantPrivilege);
 
-      return createConnection({
-        host: process.env.QUERY_DB_HOST,
-        user: username,
-        password: identify,
-        port: parseInt(process.env.QUERY_DB_PORT || '3306', 10),
-        database: identify,
-      });
-    }
+    const connection = await createConnection({
+      host: process.env.QUERY_DB_HOST,
+      user: username,
+      password: identify,
+      port: parseInt(process.env.QUERY_DB_PORT || '3306', 10),
+      database: identify,
+    });
+    this.userConnectionList[identify] = connection;
   }
 
-  public async closeConnection(connection: Connection) {
-    await connection.end();
+  public getConnection(identify: string): Connection {
+    return this.userConnectionList[identify];
   }
 
-  async run(connection: Connection, query: string): Promise<RowDataPacket[]> {
+  public async closeConnection(identify: string) {
+    await this.userConnectionList[identify].end();
+    await this.removeDatabaseInfo(identify);
+  }
+
+  public async run(
+    connection: Connection,
+    query: string,
+  ): Promise<RowDataPacket[]> {
     const [rows] = await connection.execute<RowDataPacket[]>(query);
     return rows;
   }
 
-  async dropDatabase(identify: string) {
+  private async removeDatabaseInfo(identify: string) {
     try {
       const dropDatabase = `drop database ${identify};`;
-      await this.pool.execute(dropDatabase);
+      await this.adminConnection.execute(dropDatabase);
+
+      const dropUser = `drop user '${identify.substring(0, 10)}';`;
+      await this.adminConnection.execute(dropUser);
     } catch (e) {
-      console.error(e);
+      // console.error(e);
     }
   }
 }

--- a/be/src/config/query-database/single-mysql.adapter.ts
+++ b/be/src/config/query-database/single-mysql.adapter.ts
@@ -31,21 +31,29 @@ export class SingleMySQLAdapter implements QueryDBAdapter {
 
   public async createConnection(identify: string) {
     try {
+      const username = identify.substring(0, 10);
       return await createConnection({
         host: process.env.QUERY_DB_HOST,
-        user: process.env.QUERY_DB_USERNAME,
-        password: process.env.QUERY_DB_PASSWORD,
+        user: username,
+        password: identify,
         port: parseInt(process.env.QUERY_DB_PORT || '3306', 10),
         database: identify,
       });
     } catch (e) {
       //해당 database가 없을때
+      const username = identify.substring(0, 10);
+
       const createDatabase = `create database ${identify};`;
+      const createUser = `create user '${username}'@'%' identified by '${identify}';`;
+      const grantPrivilege = `grant all privileges on ${identify}.* to '${username}'@'%';`; // 사용자 db에 대해서만 권한 부여
       await this.pool.execute(createDatabase);
+      await this.pool.execute(createUser);
+      await this.pool.execute(grantPrivilege);
+
       return createConnection({
         host: process.env.QUERY_DB_HOST,
-        user: process.env.QUERY_DB_USERNAME,
-        password: process.env.QUERY_DB_PASSWORD,
+        user: username,
+        password: identify,
         port: parseInt(process.env.QUERY_DB_PORT || '3306', 10),
         database: identify,
       });

--- a/be/src/config/redis/redis.client.ts
+++ b/be/src/config/redis/redis.client.ts
@@ -27,15 +27,18 @@ export class RedisClient {
     });
   }
 
-  getSession(key: string) {
-    return this.redis.get(key);
+  async getSession(key: string) {
+    if (!key) {
+      return null;
+    }
+    return await this.redis.get(key);
   }
 
   private subscribeToExpiredEvents() {
     this.pubsub.subscribe('__keyevent@0__:expired');
 
     this.pubsub.on('message', (event, session) => {
-      this.queryDBAdapter.dropDatabase(session);
+      this.queryDBAdapter.closeConnection(session);
     });
   }
 

--- a/be/src/query/query.controller.ts
+++ b/be/src/query/query.controller.ts
@@ -17,6 +17,7 @@ export class QueryController {
   @Post('execute')
   async executeQuery(@Req() req: Request, @Body() queryDto: QueryDto) {
     return ResponseDto.ok(
-      await this.queryService.execute(req.sessionID, queryDto));
+      await this.queryService.execute(req.sessionID, queryDto),
+    );
   }
 }

--- a/be/src/query/query.service.ts
+++ b/be/src/query/query.service.ts
@@ -11,14 +11,13 @@ export class QueryService {
   ) {}
 
   async execute(userId: string, queryDto: QueryDto) {
-    const connection = await this.queryDBAdapter.createConnection(userId);
+    const connection = this.queryDBAdapter.getConnection(userId);
     try {
       const rows = await this.queryDBAdapter.run(connection, queryDto.query);
       return ResQueryDto.ok(queryDto.query, rows);
     } catch (e) {
+      // console.error(e);
       return ResQueryDto.fail(e.sqlMessage);
-    } finally {
-      this.queryDBAdapter.closeConnection(connection);
     }
   }
 }

--- a/be/src/session/session.middleware.ts
+++ b/be/src/session/session.middleware.ts
@@ -1,35 +1,43 @@
 import session from 'express-session';
 import { NextFunction, Request, Response } from 'express';
-import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Inject, Injectable, NestMiddleware } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
-import cookieParser from 'cookie-parser';
 import RedisStore from 'connect-redis';
 import { RedisClient } from 'src/config/redis/redis.client';
+import { QUERY_DB_ADAPTER } from 'src/config/query-database/query-db.moudle';
+import { QueryDBAdapter } from 'src/config/query-database/query-db.adapter';
 
 @Injectable()
 export class SessionMiddleware implements NestMiddleware {
-  constructor(private readonly redisClient: RedisClient) {}
+  constructor(
+    private readonly redisClient: RedisClient,
+    @Inject(QUERY_DB_ADAPTER) private readonly queryDBAdapter: QueryDBAdapter,
+  ) {}
 
   use(req: Request, res: Response, next: NextFunction) {
-    cookieParser()(req, res, async () => {
-      session({
-        secret: process.env.SESSION_SECRET,
-        resave: false,
-        saveUninitialized: true,
-        rolling: true,
-        store: new RedisStore({
-          client: this.redisClient.getRedis(),
-          prefix: '',
-        }),
-        genid: () => {
-          const uuid = 'db' + uuidv4().replace(/[^a-zA-Z0-9]/g, '');
-          return uuid;
-        },
-        cookie: {
-          maxAge: 1000 * 60,
-        },
-        name: 'sid',
-      })(req, res, next);
+    session({
+      secret: process.env.SESSION_SECRET,
+      resave: false,
+      saveUninitialized: true,
+      rolling: true,
+      store: new RedisStore({
+        client: this.redisClient.getRedis(),
+        prefix: '',
+      }),
+      genid: () => {
+        const uuid = 'db' + uuidv4().replace(/[^a-zA-Z0-9]/g, '');
+        return uuid;
+      },
+      cookie: {
+        maxAge: 1000 * 60,
+      },
+      name: 'sid',
+    })(req, res, async () => {
+      const existSession = await this.redisClient.getSession(req.sessionID);
+      if (!existSession) {
+        await this.queryDBAdapter.createConnection(req.sessionID);
+      }
+      next();
     });
   }
 }

--- a/be/src/session/session.middleware.ts
+++ b/be/src/session/session.middleware.ts
@@ -33,8 +33,8 @@ export class SessionMiddleware implements NestMiddleware {
       },
       name: 'sid',
     })(req, res, async () => {
-      const existSession = await this.redisClient.getSession(req.sessionID);
-      if (!existSession) {
+      const session = await this.redisClient.getSession(req.sessionID);
+      if (!session) {
         await this.queryDBAdapter.createConnection(req.sessionID);
       }
       next();


### PR DESCRIPTION
close #16
close #69 
## 📝 기능 설명
세션마다 db connection 생성, database 생성, user 생성 기능을 구현하였습니다.

새로운 세션으로 접속하는 경우의 결과
- 세션아이디(글자수 제한으로 아이디의 앞10글자로 제한)로 mysql에 생성된 사용자
- 세션아이디로 생성된 database
- redis에 등록된 session id
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/b5ac72f2-c502-49b3-874a-9c3b50c3e1ea">

## 🛠 작업 사항
사용자 계정 생성 및 권한 할당 쿼리를 실행할 수 있도록, 항상 연결되어 있는 `adminConnection`을 생성하였습니다.
일반 사용자 connection의 경우, sessionId와 connection 객체를 map 형태로 저장하여 관리하도록 하였습니다.
```ts
private adminConnection: Connection;
private userConnectionList: Record<string, Connection> = {};
```

### 데이터베이스 생성, 사용자 생성 및 권한 부여
mysql 사용자이름은 세션id의 앞 10글자, 비밀번호는 sessionId와 동일하게 설정해두었습니다.
모든 host에서 접속 허용을 해주었는데, 이 부분은 추후 수정이 필요할 것 같습니다.

```ts
const createDatabase = `create database ${identify};`;
const createUser = `create user '${username}'@'%' identified by '${identify}';`;
const grantPrivilege = `grant all privileges on ${identify}.* to '${username}'@'%';`; // 사용자 db에 대해서만 권한 부여
```

### 세션 만료시 연결 종료
`closeConnection` 함수에서 private 함수인 `removeDatabaseInfo`함수를 호출하여 database와 user를 제거하도록 하였습니다.

## ✅ 작업 체크리스트
- [x] 세션마다 connection 생성, database 생성, user 생성 및 권한 부여
- [x] 세션 만료시 connection 제거, database 제거, user 제거

## 📎 참고 자료
