### PR TITLE
[#68] npm start:container를 통해 도커로 실행될 수 있게 한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# docker mount directory
+db

--- a/be/docker-compose.backend.local.yml
+++ b/be/docker-compose.backend.local.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   backend:
     build:
-      context: ./BE
+      context: .
     container_name: QLab-Service-Server
     ports:
       - "3000:3000"

--- a/docker-compose.backend.local.yml
+++ b/docker-compose.backend.local.yml
@@ -19,7 +19,6 @@ services:
       DB_USERNAME: root
       DB_PASSWORD: db1004
       DB_DATABASE: qlab
-
       QUERY_DB_TYPE: mysql
       QUERY_DB_HOST: query_db
       QUERY_DB_PORT: 3306
@@ -43,7 +42,7 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - server_db_data:/var/lib/mysql
+      - ./db/server:/var/lib/mysql
     networks:
       - backend
 
@@ -56,7 +55,7 @@ services:
     ports:
       - "3307:3306"
     volumes:
-      - query_db_data:/var/lib/mysql
+      - ./db/query:/var/lib/mysql
     networks:
       - backend
 
@@ -66,14 +65,9 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - redis_data:/data
+      - ./db/redis:/data
     networks:
       - backend
-
-volumes:
-  server_db_data:
-  query_db_data:
-  redis_data:
 
 networks:
   backend:

--- a/docker-compose.backend.local.yml
+++ b/docker-compose.backend.local.yml
@@ -1,0 +1,79 @@
+version: '3'
+services:
+  backend:
+    build:
+      context: ./BE
+    container_name: QLab-Service-Server
+    ports:
+      - "3000:3000"
+    depends_on:
+      - server_db
+      - query_db
+      - redis
+    networks:
+      - backend
+    environment:
+      DB_TYPE: mysql
+      DB_HOST: server_db
+      DB_PORT: 3306
+      DB_USERNAME: root
+      DB_PASSWORD: db1004
+      DB_DATABASE: qlab
+
+      QUERY_DB_TYPE: mysql
+      QUERY_DB_HOST: query_db
+      QUERY_DB_PORT: 3306
+      QUERY_DB_USER: root
+      QUERY_DB_PASSWORD: db1004
+      QUERY_DB_DATABASE: qlab
+
+      SESSION_SECRET: session-secret
+
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+    expose:
+      - 3000
+
+  server_db:
+    image: mysql:8.0
+    container_name: server_db
+    environment:
+      MYSQL_ROOT_PASSWORD: db1004
+      MYSQL_DATABASE: qlab
+    ports:
+      - "3306:3306"
+    volumes:
+      - server_db_data:/var/lib/mysql
+    networks:
+      - backend
+
+  query_db:
+    image: mysql:8.0
+    container_name: query_db
+    environment:
+      MYSQL_ROOT_PASSWORD: db1004
+      MYSQL_DATABASE: qlab
+    ports:
+      - "3307:3306"
+    volumes:
+      - query_db_data:/var/lib/mysql
+    networks:
+      - backend
+
+  redis:
+    image: redis:latest
+    container_name: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - backend
+
+volumes:
+  server_db_data:
+  query_db_data:
+  redis_data:
+
+networks:
+  backend:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "web36-qlab",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start:container": "docker-compose -f docker-compose.backend.local.yml up --build"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start:container": "docker-compose -f docker-compose.backend.local.yml up --build"
+    "start:container": "docker-compose -f ./BE/docker-compose.backend.local.yml up --build"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
close #68 

## 📝 기능 설명
프로젝트 최상단에서 `npm start:container`스크립트를 실행할 수 있습니다.
해당 스크립트를 실행하면, 로컬 환경에서 테스트가 가능하도록 mysql, redis 서버를 도커에 띄우고 nest 서버가 동작합니다.
파일이 실행되면 db 디렉터리에 query, server, redis디렉터리들이 추가되고 해당 파일에 db 정보들이 저장됩니다.

- 포트번호
  - redis: 6379
  - mysql-server: 3306
  - mysql-query: 3307

## 🛠 작업 사항
docker-compose 파일 작성

## ✅ 작업 체크리스트
- [x] mysql, redis 서버
- [x] nest 서버가 동작하여 api 실행 가능
