### PR TITLE
[#18 #19] 서버에서 쿼리 실행 결과를 성공적으로 받으면 결과창에 결과를 띄운다.

### DIFF
--- a/FE/src/components/Shell.tsx
+++ b/FE/src/components/Shell.tsx
@@ -2,6 +2,14 @@ import React, { useState, useRef } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import PlayCircle from '@/assets/play_circle.svg'
 import { ShellType } from '@/types/interfaces'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 import { X } from 'lucide-react'
 
 interface ShellProps {
@@ -63,23 +71,39 @@ export default function Shell({
         )}
       </div>
       {queryType != null && ( // 쉘 실행 결과가 있는가?
-        <div className="flex w-full flex-col overflow-hidden rounded-sm bg-secondary">
-          <div className="m-3">
-            {queryStatus ? (
-              <p className="text-green-500">{successMessage}</p>
-            ) : (
-              <p className="text-red-500">{failMessage}</p>
-            )}
-            {queryType === 'SELECT' && <p>{JSON.stringify(table)}</p>}
-          </div>
-          {queryType === 'SELECT' && (
-            <button
-              type="button"
-              className="flex w-full justify-center bg-primary"
-            >
-              <div className="text-bold w-3 text-background">+</div>
-            </button>
+        <div className="flex w-full flex-col overflow-hidden overflow-x-auto rounded-sm bg-secondary p-3">
+          {queryStatus ? (
+            <p className="text-green-500">{successMessage}</p>
+          ) : (
+            <p className="text-red-500">{failMessage}</p>
           )}
+          {queryType === 'SELECT' &&
+            table !== null && ( // 결과 테이블이 있는지
+              <>
+                <Table>
+                  <TableHeader>
+                    {Object.keys(table[0]).map((header) => (
+                      <TableHead key={uuidv4()}>{header}</TableHead>
+                    ))}
+                  </TableHeader>
+                  <TableBody>
+                    {table.map((row) => (
+                      <TableRow key={uuidv4()}>
+                        {Object.values(row).map((cell) => (
+                          <TableCell key={uuidv4()}>{cell}</TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                <button
+                  type="button"
+                  className="flex w-full justify-center bg-primary"
+                >
+                  <div className="text-bold w-3 text-background">+</div>
+                </button>
+              </>
+            )}
         </div>
       )}
     </>

--- a/FE/src/components/Shell.tsx
+++ b/FE/src/components/Shell.tsx
@@ -71,16 +71,16 @@ export default function Shell({
         )}
       </div>
       {queryType != null && ( // 쉘 실행 결과가 있는가?
-        <div className="flex w-full flex-col overflow-hidden overflow-x-auto rounded-sm bg-secondary p-3">
+        <div className="flex w-full flex-col overflow-hidden overflow-x-auto rounded-sm bg-secondary">
           {queryStatus ? (
-            <p className="text-green-500">{successMessage}</p>
+            <p className="m-3 text-green-500">{successMessage}</p>
           ) : (
-            <p className="text-red-500">{failMessage}</p>
+            <p className="m-3 text-red-500">{failMessage}</p>
           )}
           {queryType === 'SELECT' &&
             table !== null && ( // 결과 테이블이 있는지
               <>
-                <Table>
+                <Table className="m-3">
                   <TableHeader>
                     {Object.keys(table[0]).map((header) => (
                       <TableHead key={uuidv4()}>{header}</TableHead>

--- a/FE/src/components/Shell.tsx
+++ b/FE/src/components/Shell.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 import PlayCircle from '@/assets/play_circle.svg'
 import { ShellType } from '@/types/interfaces'
 import { X } from 'lucide-react'
@@ -64,7 +65,11 @@ export default function Shell({
       {queryType != null && ( // 쉘 실행 결과가 있는가?
         <div className="flex w-full flex-col overflow-hidden rounded-sm bg-secondary">
           <div className="m-3">
-            <p>{queryStatus ? successMessage : failMessage}</p>
+            {queryStatus ? (
+              <p className="text-green-500">{successMessage}</p>
+            ) : (
+              <p className="text-red-500">{failMessage}</p>
+            )}
             {queryType === 'SELECT' && <p>{JSON.stringify(table)}</p>}
           </div>
           {queryType === 'SELECT' && (

--- a/FE/src/components/ui/table.tsx
+++ b/FE/src/components/ui/table.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react'
+
+import cn from '@/lib/utils'
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn('w-full caption-bottom text-sm', className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = 'Table'
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+))
+TableHeader.displayName = 'TableHeader'
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
+))
+TableBody.displayName = 'TableBody'
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = 'TableFooter'
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = 'TableRow'
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = 'TableHead'
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      'p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      className
+    )}
+    {...props}
+  />
+))
+TableCell.displayName = 'TableCell'
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn('mt-4 text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+TableCaption.displayName = 'TableCaption'
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
## 📝 기능 설명
서버에서 받아온 결과를 결과창에 띄우는 기능을 구현했습니다.

<br>

## 🛠 작업 사항
- 평문 띄우기 : 평문 텍스트를 띄우고, 성공 평문은 초록, 에러는 빨강색으로 띄웠습니다.
- 테이블 결과 띄우기 : 테이블 결과가 있다면, 해당 결과를 테이블로 띄워줬습니다.

<br>

## ✅ 작업 체크리스트
- [x] 평문 띄우기
- [x] 테이블 결과 띄우기

<br>

## 📎 참고 자료
<img width="1159" alt="스크린샷 2024-11-14 오전 1 21 42" src="https://github.com/user-attachments/assets/7152298e-9194-41ff-8182-cd9962548c2c">
