### PR TITLE
[#116] 쿼리 타입 분기

### DIFF
--- a/BE/src/common/enums/query-type.enum.ts
+++ b/BE/src/common/enums/query-type.enum.ts
@@ -7,7 +7,16 @@ export const QueryType = {
   DELETE: 'DELETE',
   SELECT: 'SELECT',
   EXPLAIN: 'EXPLAIN',
-  UNKNOWN: 'UNKNOWN',
+  SHOW: 'SHOW',
+  TRUNCATE: 'TRUNCATE',
+  RENAME: 'RENAME',
+  START: 'START',
+  COMMIT: 'COMMIT',
+  ROLLBACK: 'ROLLBACK',
+  SAVEPOINT: 'SAVEPOINT',
+  DESCRIBE: 'DESCRIBE',
+  SET: 'SET',
+  UNKNOWN: 'UNKNOWN', // USE, GRANT, REVOKE
 } as const;
 
 export type QueryType = (typeof QueryType)[keyof typeof QueryType];

--- a/BE/src/common/enums/query-type.enum.ts
+++ b/BE/src/common/enums/query-type.enum.ts
@@ -6,6 +6,7 @@ export const QueryType = {
   UPDATE: 'UPDATE',
   DELETE: 'DELETE',
   SELECT: 'SELECT',
+  EXPLAIN: 'EXPLAIN',
   UNKNOWN: 'UNKNOWN',
 } as const;
 

--- a/BE/src/config/query-database/single-mysql.adapter.ts
+++ b/BE/src/config/query-database/single-mysql.adapter.ts
@@ -74,7 +74,7 @@ export class SingleMySQLAdapter implements QueryDBAdapter {
 
   public async run(identify: string, query: string): Promise<RowDataPacket[]> {
     const connection = this.userConnectionList[identify];
-    const [rows] = await connection.execute<RowDataPacket[]>(query);
+    const [rows] = await connection.query<RowDataPacket[]>(query);
     return rows;
   }
 

--- a/BE/src/config/redis/redis.service.ts
+++ b/BE/src/config/redis/redis.service.ts
@@ -49,7 +49,7 @@ export class RedisService {
     if (!session) {
       await this.queryDBAdapter.initUserDatabase(key);
     }
-    this.queryDBAdapter.createConnection(key);
+    await this.queryDBAdapter.createConnection(key);
   }
 
   private subscribeToExpiredEvents() {

--- a/BE/src/config/service-database/service-db.module.ts
+++ b/BE/src/config/service-database/service-db.module.ts
@@ -16,7 +16,7 @@ dotenv.config();
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
       entities: [User, Shell],
-      synchronize: false,
+      synchronize: true,
     }),
   ],
   exports: [TypeOrmModule],

--- a/BE/src/query/query.service.ts
+++ b/BE/src/query/query.service.ts
@@ -30,7 +30,7 @@ export class QueryService {
         ...baseUpdateData,
         affectedRows: rows.length,
         queryStatus: true,
-        ...(baseUpdateData.queryType === QueryType.SELECT && {
+        ...(this.existResultTable(baseUpdateData.queryType) && {
           resultTable: slicedRows,
         }),
         runTime: runTime,
@@ -48,6 +48,11 @@ export class QueryService {
       };
       return await this.shellService.replace(shellId, updateData);
     }
+  }
+
+  private existResultTable(type: QueryType) {
+    const validTypes: QueryType[] = [QueryType.SELECT, QueryType.EXPLAIN];
+    return validTypes.includes(type);
   }
 
   private async measureQueryRunTime(sessionId: string): Promise<string> {
@@ -81,6 +86,7 @@ export class QueryService {
     CREATE: QueryType.CREATE,
     DROP: QueryType.DROP,
     ALTER: QueryType.ALTER,
+    EXPLAIN: QueryType.EXPLAIN,
     UNKNOWN: QueryType.UNKNOWN,
   };
 }

--- a/BE/src/query/query.service.ts
+++ b/BE/src/query/query.service.ts
@@ -51,7 +51,12 @@ export class QueryService {
   }
 
   private existResultTable(type: QueryType) {
-    const validTypes: QueryType[] = [QueryType.SELECT, QueryType.EXPLAIN];
+    const validTypes: QueryType[] = [
+      QueryType.SELECT,
+      QueryType.EXPLAIN,
+      QueryType.SHOW,
+      QueryType.DESCRIBE,
+    ];
     return validTypes.includes(type);
   }
 
@@ -87,6 +92,15 @@ export class QueryService {
     DROP: QueryType.DROP,
     ALTER: QueryType.ALTER,
     EXPLAIN: QueryType.EXPLAIN,
+    SHOW: QueryType.SHOW,
+    TRUNCATE: QueryType.TRUNCATE,
+    RENAME: QueryType.RENAME,
+    START: QueryType.START,
+    COMMIT: QueryType.COMMIT,
+    ROLLBACK: QueryType.ROLLBACK,
+    SAVEPOINT: QueryType.SAVEPOINT,
+    DESCRIBE: QueryType.DESCRIBE,
+    SET: QueryType.SET,
     UNKNOWN: QueryType.UNKNOWN,
   };
 }

--- a/BE/src/query/query.service.ts
+++ b/BE/src/query/query.service.ts
@@ -21,6 +21,13 @@ export class QueryService {
       queryType: this.detectQueryType(queryDto.query),
     };
     try {
+      if (baseUpdateData.queryType === QueryType.UNKNOWN) {
+        return await this.shellService.replace(shellId, {
+          ...baseUpdateData,
+          queryStatus: false,
+          text: '지원하지 않는 쿼리입니다.',
+        });
+      }
       const rows = await this.queryDBAdapter.run(sessionId, queryDto.query);
       const slicedRows = rows.length > 100 ? rows.slice(0, 100) : rows;
       const runTime = await this.measureQueryRunTime(sessionId);

--- a/BE/src/shell/shell.service.ts
+++ b/BE/src/shell/shell.service.ts
@@ -40,7 +40,7 @@ export class ShellService {
 
     const shellInstance = new Shell();
     Object.keys(shellInstance).forEach((key) => {
-      if (!updatedShell[key]) {
+      if (updatedShell[key] === null) {
         updatedShell[key] = null;
       }
     });

--- a/BE/src/shell/shell.service.ts
+++ b/BE/src/shell/shell.service.ts
@@ -44,7 +44,6 @@ export class ShellService {
         updatedShell[key] = null;
       }
     });
-    console.log(updatedShell);
     return this.shellRepository.save(updatedShell);
   }
 

--- a/BE/test/query/query.service.spec.ts
+++ b/BE/test/query/query.service.spec.ts
@@ -3,8 +3,8 @@ import { QueryDto } from '../../src/query/dto/query.dto';
 import { QueryDBAdapter } from '../../src/config/query-database/query-db.adapter';
 import { Test, TestingModule } from '@nestjs/testing';
 import { QUERY_DB_ADAPTER } from '../../src/config/query-database/query-db.moudle';
-import { Connection } from 'mysql2/promise';
 import { ShellService } from '../../src/shell/shell.service';
+import { repl } from '@nestjs/core';
 
 describe('QueryService', () => {
   let queryService: QueryService;
@@ -27,6 +27,7 @@ describe('QueryService', () => {
           useValue: {
             findShellOrThrow: jest.fn(),
             update: jest.fn(),
+            replace: jest.fn(),
           },
         },
       ],
@@ -52,7 +53,7 @@ describe('QueryService', () => {
 
       await queryService.execute(sessionId, shellId, queryDto);
 
-      expect(mockShellService.update).toHaveBeenCalledWith(
+      expect(mockShellService.replace).toHaveBeenCalledWith(
         shellId,
         expect.objectContaining({
           resultTable: rows.slice(0, 100),
@@ -66,7 +67,7 @@ describe('QueryService', () => {
 
       await queryService.execute(sessionId, shellId, queryDto);
 
-      expect(mockShellService.update).toHaveBeenCalledWith(
+      expect(mockShellService.replace).toHaveBeenCalledWith(
         shellId,
         expect.objectContaining({
           resultTable: rows,


### PR DESCRIPTION
close #116 
## 📝 기능 설명
서비스에서 지원하는 쿼리 목록들을 추가하였습니다.
해당 쿼리의 반환값에 따라서 resultTable의 존재 여부를 설정해주었습니다.

## 🛠 작업 사항
지원하는 쿼리 타입을 enum에 추가하였습니다.
```
export const QueryType = {
  CREATE: 'CREATE',
  ALTER: 'ALTER',
  DROP: 'DROP',
  INSERT: 'INSERT',
  UPDATE: 'UPDATE',
  DELETE: 'DELETE',
  SELECT: 'SELECT',
  EXPLAIN: 'EXPLAIN',
  SHOW: 'SHOW',
  TRUNCATE: 'TRUNCATE',
  RENAME: 'RENAME',
  START: 'START',
  COMMIT: 'COMMIT',
  ROLLBACK: 'ROLLBACK',
  SAVEPOINT: 'SAVEPOINT',
  DESCRIBE: 'DESCRIBE',
  SET: 'SET',
  UNKNOWN: 'UNKNOWN', // USE, GRANT, REVOKE
} as const;
```

지원하지 않는 쿼리는 UNKNOWN타입으로 지정됩니다. UNKNOWN으로 타입이 지정되는 경우는 queryStatus: false와 경고 문구를 전달합니다.
```
if (baseUpdateData.queryType === QueryType.UNKNOWN) {
        return await this.shellService.replace(shellId, {
          ...baseUpdateData,
          queryStatus: false,
          text: '지원하지 않는 쿼리입니다.',
        });
      }
```


반환값에 resultTable이 존재하는 쿼리를 확인하여 넣어주었습니다.
```
 private existResultTable(type: QueryType) {
    const validTypes: QueryType[] = [
      QueryType.SELECT,
      QueryType.EXPLAIN,
      QueryType.SHOW,
      QueryType.DESCRIBE,
    ];
    return validTypes.includes(type);
  }
```



## ✅ 작업 체크리스트
- [x] 쿼리 타입 지정 및 분기
- [x] unknown 타입 설정 및 응답값 설정

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
[SQL문 결과](https://www.notion.so/SQL-13362570e7c480369998c76c05276e0e?pvs=4)