### PR TITLE
[#155] 스토리지 사용량 UI 레이아웃

### DIFF
--- a/FE/src/components/CapacityUsage.tsx
+++ b/FE/src/components/CapacityUsage.tsx
@@ -1,9 +1,10 @@
 import { CapacityUsageProps } from '@/types/interfaces'
+import { MAX_ROWS_PER_USER } from '@/constants/constants'
 
 function CapacityUsage({
   used,
-  total,
-  unit = 'GB',
+  total = MAX_ROWS_PER_USER,
+  unit = 'Rows',
   lowThreshold = 70,
   highThreshold = 70,
   isLoading = false, // 로딩 상태 추가

--- a/FE/src/components/CapacityUsage.tsx
+++ b/FE/src/components/CapacityUsage.tsx
@@ -1,0 +1,54 @@
+import { CapacityUsageProps } from '@/types/interfaces'
+
+function CapacityUsage({
+  used,
+  total,
+  unit = 'GB',
+  lowThreshold = 70,
+  highThreshold = 70,
+  isLoading = false, // 로딩 상태 추가
+}: CapacityUsageProps) {
+  const percentage = !isLoading && total > 0 ? (used / total) * 100 : 0
+
+  const getColor = (percent: number) => {
+    if (percent < lowThreshold) return 'bg-primary'
+    if (percent < highThreshold) return 'bg-yellow-500'
+    return 'bg-red-500'
+  }
+
+  const color = getColor(percentage)
+
+  return (
+    <div className="flex max-w-md items-center space-x-2 rounded-lg bg-white">
+      {/* 게이지 바 */}
+      <div className="w-24 flex-grow">
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-200">
+          <div
+            className={`h-full ${color}`}
+            style={{ width: `${percentage}%` }}
+          ></div>
+        </div>
+      </div>
+
+      {/* 텍스트 영역 */}
+      <div className="flex-shrink-0 text-left text-xs font-semibold text-muted-foreground">
+        <div className="flex items-center space-x-1">
+          {/* 현재 사용량 */}
+          {isLoading ? (
+            <div className="mb-0.5 h-3 w-3 animate-spin rounded-full border-2 border-gray-300 border-t-blue-500"></div>
+          ) : (
+            <span>{used}</span>
+          )}
+          {/* 단위 */}
+          <span>{unit}</span>
+          {/* 총 사용량 */}
+          <span>
+            / {total} {unit}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CapacityUsage

--- a/FE/src/components/ShellList.tsx
+++ b/FE/src/components/ShellList.tsx
@@ -8,7 +8,7 @@ export default function ShellList({ shells = [] }: { shells: ShellType[] }) {
   const { addShell } = useShellHandlers()
   return (
     <>
-      <div className="sticky top-0 flex items-center justify-between border-b bg-background p-2">
+      <div className="sticky top-0 flex items-center justify-between border-b bg-background p-2 px-4">
         {/* 버튼 그룹 */}
         <div className="flex items-center gap-2">
           <Badge
@@ -25,9 +25,7 @@ export default function ShellList({ shells = [] }: { shells: ShellType[] }) {
       </div>
       {shells.length > 0 && (
         <div className="flex flex-1 flex-col gap-3 p-4">
-          {shells.map((shell) => (
-            <Shell key={shell.id} shell={shell} />
-          ))}
+          {shells?.map((shell) => <Shell key={shell.id} shell={shell} />)}
         </div>
       )}
     </>

--- a/FE/src/components/ShellList.tsx
+++ b/FE/src/components/ShellList.tsx
@@ -21,7 +21,7 @@ export default function ShellList({ shells = [] }: { shells: ShellType[] }) {
         </div>
 
         {/* 점유율 컴포넌트 */}
-        <CapacityUsage used={800} total={1000} unit="GB" isLoading />
+        <CapacityUsage used={800} isLoading />
       </div>
       {shells.length > 0 && (
         <div className="flex flex-1 flex-col gap-3 p-4">

--- a/FE/src/components/ShellList.tsx
+++ b/FE/src/components/ShellList.tsx
@@ -4,27 +4,24 @@ import { ShellType } from '@/types/interfaces'
 import useShellHandlers from '@/hooks/useShellHandler'
 import CapacityUsage from './CapacityUsage'
 
-function ButtonGroup({ onAddShell }: { onAddShell: () => void }) {
-  return (
-    <div className="flex items-center gap-2">
-      <Badge variant="outline" className="cursor-pointer" onClick={onAddShell}>
-        + query
-      </Badge>
-    </div>
-  )
-}
-
 export default function ShellList({ shells = [] }: { shells: ShellType[] }) {
   const { addShell } = useShellHandlers()
-
   return (
     <>
       <div className="sticky top-0 flex items-center justify-between border-b bg-background p-2">
         {/* 버튼 그룹 */}
-        <ButtonGroup onAddShell={addShell} />
+        <div className="flex items-center gap-2">
+          <Badge
+            variant="outline"
+            className="cursor-pointer"
+            onClick={addShell}
+          >
+            + query
+          </Badge>
+        </div>
 
         {/* 점유율 컴포넌트 */}
-        <CapacityUsage used={400} total={1000} unit="GB" />
+        <CapacityUsage used={800} total={1000} unit="GB" isLoading />
       </div>
       {shells.length > 0 && (
         <div className="flex flex-1 flex-col gap-3 p-4">

--- a/FE/src/components/ShellList.tsx
+++ b/FE/src/components/ShellList.tsx
@@ -2,20 +2,35 @@ import { Badge } from '@/components/ui/badge'
 import Shell from '@/components/Shell'
 import { ShellType } from '@/types/interfaces'
 import useShellHandlers from '@/hooks/useShellHandler'
+import CapacityUsage from './CapacityUsage'
+
+function ButtonGroup({ onAddShell }: { onAddShell: () => void }) {
+  return (
+    <div className="flex items-center gap-2">
+      <Badge variant="outline" className="cursor-pointer" onClick={onAddShell}>
+        + query
+      </Badge>
+    </div>
+  )
+}
 
 export default function ShellList({ shells = [] }: { shells: ShellType[] }) {
   const { addShell } = useShellHandlers()
 
   return (
     <>
-      <div className="sticky top-0 flex shrink-0 items-center gap-3 border-b bg-background p-2">
-        <Badge variant="outline" className="cursor-pointer" onClick={addShell}>
-          + query
-        </Badge>
+      <div className="sticky top-0 flex items-center justify-between border-b bg-background p-2">
+        {/* 버튼 그룹 */}
+        <ButtonGroup onAddShell={addShell} />
+
+        {/* 점유율 컴포넌트 */}
+        <CapacityUsage used={400} total={1000} unit="GB" />
       </div>
       {shells.length > 0 && (
         <div className="flex flex-1 flex-col gap-3 p-4">
-          {shells?.map((shell) => <Shell key={shell.id} shell={shell} />)}
+          {shells.map((shell) => (
+            <Shell key={shell.id} shell={shell} />
+          ))}
         </div>
       )}
     </>

--- a/FE/src/components/TestTool.tsx
+++ b/FE/src/components/TestTool.tsx
@@ -34,7 +34,6 @@ export default function TestQueryTool() {
 
   return (
     <div className="shadow-sm">
-      {/* Query List */}
       <div className="mb-4">
         <p
           id="query-list-label"
@@ -70,7 +69,6 @@ export default function TestQueryTool() {
         </div>
       </div>
 
-      {/* Selected Query Display */}
       <div className="mb-4">
         <div className="mb-3 block flex h-10 items-center justify-between border-b border-t bg-secondary pl-3 text-sm font-medium text-muted-foreground transition-colors">
           <p id="selected-query-label">Preview / Edit Query</p>
@@ -97,7 +95,6 @@ export default function TestQueryTool() {
         />
       </div>
 
-      {/* Action Button */}
       <div className="px-4">
         <Button onClick={handleRunQuery} variant="default" className="w-full">
           Add Query

--- a/FE/src/constants/constants.ts
+++ b/FE/src/constants/constants.ts
@@ -35,6 +35,8 @@ export const MENU = [
   },
 ]
 
+export const MAX_ROWS_PER_USER = 50000
+
 export const COLUMN_TYPES = [
   'TINYINT',
   'SMALLINT',

--- a/FE/src/types/interfaces.ts
+++ b/FE/src/types/interfaces.ts
@@ -74,7 +74,7 @@ export interface ExampleQuery {
 
 export interface CapacityUsageProps {
   used: number
-  total: number
+  total?: number
   unit?: string
   lowThreshold?: number
   highThreshold?: number

--- a/FE/src/types/interfaces.ts
+++ b/FE/src/types/interfaces.ts
@@ -71,3 +71,12 @@ export interface ExampleQuery {
   name: string
   query: string
 }
+
+export interface CapacityUsageProps {
+  used: number
+  total: number
+  unit?: string
+  lowThreshold?: number
+  highThreshold?: number
+  isLoading?: boolean
+}


### PR DESCRIPTION
## 📝 기능 설명
<!-- 제안하는 기능에 대해 명확하고 간단히 설명해주세요 -->
사용자의 스토리지 사용 점유율을 구현하였습니다.

## 🛠 작업 사항
<!-- 구현한 작업 내용을 설명해주세요 -->
`fetch` 중일 때 로딩 애니메이션을 추가하였습니다.
사용량을 바로 보여주고 전체 샤용량과 현재 사용량을 보여주게 하였습니다.
## ✅ 작업 체크리스트
- [x] `fetch` 중일 때 로딩 애니메이션
- [x] 점유율 바 - 사용량에 따른 색깔 변경
- [x] 현재 사용량 / 전체 사용량

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
<img width="236" alt="image" src="https://github.com/user-attachments/assets/1a154552-5025-4d08-9b2f-7aed7b12cceb">  <br>
<img width="224" alt="image" src="https://github.com/user-attachments/assets/86d03a26-7b38-43dc-8d42-cc4af3be1395">  <br>
<img width="219" alt="image" src="https://github.com/user-attachments/assets/ec3712a3-ce20-40ab-84ef-fd82ecfe4af1">  <br>