### PR TITLE
[#157] 사용자별 데이터 용량을 조회한다.

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -12,6 +12,7 @@ import { RedisModule } from './config/redis/redis.module';
 import { ServiceDBModule } from './config/service-database/service-db.module';
 import { RecordModule } from './record/record.module';
 import { TableModule } from './table/table.module';
+import { UsageModule } from './usage/useage.module';
 
 dotenv.config();
 
@@ -25,6 +26,7 @@ dotenv.config();
     RedisModule,
     RecordModule,
     TableModule,
+    UsageModule,
   ],
 })
 export class AppModule {

--- a/BE/src/config/query-database/query-db.adapter.ts
+++ b/BE/src/config/query-database/query-db.adapter.ts
@@ -3,7 +3,7 @@ import { Connection, Pool, QueryResult } from 'mysql2/promise';
 export interface QueryDBAdapter {
   createConnection(): Promise<void>;
   initUserDatabase(): Promise<void>;
-  closeConnection(): Promise<void>;
+  closeConnection(identify: string): Promise<void>;
   run(query: string): Promise<QueryResult>;
   getConnection(): Connection;
   getAdminPool(): Pool;

--- a/BE/src/config/query-database/single-mysql.adapter.ts
+++ b/BE/src/config/query-database/single-mysql.adapter.ts
@@ -89,10 +89,10 @@ export class SingleMySQLAdapter implements QueryDBAdapter {
     await this.run('set profiling = 1;');
   }
 
-  public async closeConnection() {
-    await this.singleMySQLConnectionManager.closeConnection(this.getSID());
-    await this.removeDatabaseInfo();
-    this.singleMySQLConnectionManager.deleteConnection(this.getSID());
+  public async closeConnection(identify: string) {
+    await this.singleMySQLConnectionManager.closeConnection(identify);
+    await this.removeDatabaseInfo(identify);
+    this.singleMySQLConnectionManager.deleteConnection(identify);
   }
 
   public async run(query: string) {
@@ -101,13 +101,13 @@ export class SingleMySQLAdapter implements QueryDBAdapter {
     return result;
   }
 
-  private async removeDatabaseInfo() {
+  private async removeDatabaseInfo(identify: string) {
     try {
       const adminConnection = this.singleMySQLConnectionManager.getAdminPool();
-      const dropDatabase = `drop database ${this.getSID()};`;
+      const dropDatabase = `drop database ${identify};`;
       await adminConnection.execute(dropDatabase);
 
-      const dropUser = `drop user '${this.getSID().substring(0, 10)}';`;
+      const dropUser = `drop user '${identify.substring(0, 10)}';`;
       await adminConnection.execute(dropUser);
     } catch (e) {
       console.error(e);

--- a/BE/src/config/redis/custom-redis.store.ts
+++ b/BE/src/config/redis/custom-redis.store.ts
@@ -1,0 +1,46 @@
+import { SessionData, Store } from 'express-session';
+import { RedisService } from './redis.service';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CustomRedisStore extends Store {
+  constructor(@Inject() private readonly redisService: RedisService) {
+    super();
+  }
+
+  async set(
+    sid: string,
+    session: SessionData,
+    cb: (err?: any) => void,
+  ): Promise<void> {
+    try {
+      const ttl = (session.cookie.maxAge / 1000) | (60 * 60); // 기본값: 1시간 (sec)
+      await this.redisService.setSession(sid, session.cookie);
+      await this.redisService.setExpireTime(sid, ttl);
+      return cb();
+    } catch (err) {
+      cb(err);
+    }
+  }
+
+  async get(
+    sid: string,
+    cb: (err: any, session?: SessionData | null) => void,
+  ): Promise<void> {
+    try {
+      const data = await this.redisService.getSession(sid);
+      return cb(data);
+    } catch (err) {
+      return cb(err);
+    }
+  }
+
+  async destroy(sid: string, cb: (err?: any) => void): Promise<void> {
+    try {
+      await this.redisService.deleteSession(sid);
+      return cb();
+    } catch (err) {
+      cb(err);
+    }
+  }
+}

--- a/BE/src/config/redis/redis.service.ts
+++ b/BE/src/config/redis/redis.service.ts
@@ -41,15 +41,32 @@ export class RedisService {
     if (!key) {
       return null;
     }
-    return this.defaultConnection.get(key);
+    return this.defaultConnection.hget(key, 'session');
   }
 
-  public async setNewSession(key: string) {
-    const session = await this.getSession(key);
+  public async existSession(key: string) {
+    return this.defaultConnection.exists(key);
+  }
+
+  public async setSession(key: string, sessionInfo: object) {
+    await this.defaultConnection.hset(key, 'session', JSON.stringify(sessionInfo));
+  }
+
+  public async setNewSession(key: string, sessionInfo: object) {
+    const session = await this.existSession(key);
     if (!session) {
+      await this.defaultConnection.hset(key, 'session', JSON.stringify(sessionInfo));
       await this.queryDBAdapter.initUserDatabase();
     }
     await this.queryDBAdapter.createConnection();
+  }
+
+  public async deleteSession(key: string) {
+    await this.defaultConnection.del(key);
+  }
+
+  public async setExpireTime(key: string, ttl: number) {
+    await this.defaultConnection.expire(key, ttl);
   }
 
   private subscribeToExpiredEvents() {

--- a/BE/src/config/redis/redis.service.ts
+++ b/BE/src/config/redis/redis.service.ts
@@ -55,8 +55,8 @@ export class RedisService {
   private subscribeToExpiredEvents() {
     this.eventConnection.subscribe('__keyevent@0__:expired');
 
-    this.eventConnection.on('message', () => {
-      this.queryDBAdapter.closeConnection();
+    this.eventConnection.on('message', (event, session) => {
+      this.queryDBAdapter.closeConnection(session);
     });
   }
 

--- a/BE/src/config/redis/redis.service.ts
+++ b/BE/src/config/redis/redis.service.ts
@@ -56,6 +56,7 @@ export class RedisService {
     const session = await this.existSession(key);
     if (!session) {
       await this.defaultConnection.hset(key, 'session', JSON.stringify(sessionInfo));
+      await this.defaultConnection.hset(key, 'rowCount', 0);
       await this.queryDBAdapter.initUserDatabase();
     }
     await this.queryDBAdapter.createConnection();
@@ -75,6 +76,14 @@ export class RedisService {
     this.eventConnection.on('message', (event, session) => {
       this.queryDBAdapter.closeConnection(session);
     });
+  }
+
+  public async getRowCount(identify: string) {
+    return this.defaultConnection.hget(identify, 'rowCount');
+  }
+
+  public async updateRowCount(identify: string, rowCount: number) {
+    await this.defaultConnection.hset(identify, 'rowCount', rowCount);
   }
 
   public getDefaultConnection() {

--- a/BE/src/middleware/session.middleware.ts
+++ b/BE/src/middleware/session.middleware.ts
@@ -2,7 +2,7 @@ import session from 'express-session';
 import { NextFunction, Request, Response } from 'express';
 import { Injectable, NestMiddleware } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
-import RedisStore from 'connect-redis';
+import { CustomRedisStore } from 'src/config/redis/custom-redis.store';
 import { RedisService } from 'src/config/redis/redis.service';
 
 @Injectable()
@@ -15,19 +15,16 @@ export class SessionMiddleware implements NestMiddleware {
       resave: false,
       saveUninitialized: true,
       rolling: true,
-      store: new RedisStore({
-        client: this.redisService.getDefaultConnection(),
-        prefix: '',
-      }),
+      store: new CustomRedisStore(this.redisService),
       genid: () => {
         return 'db' + uuidv4().replace(/[^a-zA-Z0-9]/g, '');
       },
       cookie: {
-        maxAge: 1000 * 60 * 60,
+        maxAge: 1000 * 60 * 60, // 1시간 (ms)
       },
       name: 'sid',
     })(req, res, async () => {
-      await this.redisService.setNewSession(req.sessionID);
+      await this.redisService.setNewSession(req.sessionID, req.session);
       next();
     });
   }

--- a/BE/src/query/query.module.ts
+++ b/BE/src/query/query.module.ts
@@ -5,10 +5,12 @@ import { QueryDBModule } from '../config/query-database/query-db.moudle';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Shell } from '../shell/shell.entity';
 import { ShellService } from '../shell/shell.service';
+import { UsageService } from 'src/usage/usage.service';
+import { RedisModule } from 'src/config/redis/redis.module';
 
 @Module({
-  imports: [QueryDBModule, TypeOrmModule.forFeature([Shell])],
+  imports: [QueryDBModule, TypeOrmModule.forFeature([Shell]), RedisModule],
   controllers: [QueryController],
-  providers: [QueryService, ShellService],
+  providers: [QueryService, ShellService, UsageService],
 })
 export class QueryModule {}

--- a/BE/src/query/query.service.ts
+++ b/BE/src/query/query.service.ts
@@ -6,12 +6,14 @@ import { QueryType } from '../common/enums/query-type.enum';
 import { ShellService } from '../shell/shell.service';
 import { ResultSetHeader, RowDataPacket } from 'mysql2/promise';
 import { Shell } from '../shell/shell.entity';
+import { UsageService } from 'src/usage/usage.service';
 
 @Injectable()
 export class QueryService {
   constructor(
     @Inject(QUERY_DB_ADAPTER) private readonly queryDBAdapter: QueryDBAdapter,
     private shellService: ShellService,
+    private readonly usageService: UsageService,
   ) {}
 
   async execute(sessionId: string, shellId: number, queryDto: QueryDto) {
@@ -59,6 +61,9 @@ export class QueryService {
 
     const rows = await this.queryDBAdapter.run(query);
     const runTime = await this.measureQueryRunTime(sessionId);
+
+    // Update usage
+    this.usageService.updateRowCount(sessionId);
 
     let text: string;
     let resultTable: RowDataPacket[];

--- a/BE/src/record/record.module.ts
+++ b/BE/src/record/record.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { RecordController } from './record.controller';
 import { RecordService } from './record.service';
 import { QueryDBModule } from 'src/config/query-database/query-db.moudle';
+import { UsageService } from 'src/usage/usage.service';
+import { RedisModule } from 'src/config/redis/redis.module';
 
 @Module({
-  imports: [QueryDBModule],
+  imports: [QueryDBModule, RedisModule],
   controllers: [RecordController],
-  providers: [RecordService],
+  providers: [RecordService, UsageService],
 })
 export class RecordModule {}

--- a/BE/src/record/record.service.ts
+++ b/BE/src/record/record.service.ts
@@ -24,6 +24,7 @@ import fs from 'fs/promises';
 import crypto from 'crypto';
 import path from 'path';
 import { ResultSetHeader } from 'mysql2';
+import { UsageService } from 'src/usage/usage.service';
 
 const RANDOM_DATA_TEMP_DIR = 'csvTemp';
 const RECORD_PROCESS_BATCH_SIZE = 10000;
@@ -52,6 +53,7 @@ const TypeToConstructor = {
 export class RecordService implements OnModuleInit {
   constructor(
     @Inject(QUERY_DB_ADAPTER) private readonly queryDBAdapter: QueryDBAdapter,
+    private readonly usageService: UsageService,
   ) {}
 
   async onModuleInit() {
@@ -202,6 +204,8 @@ export class RecordService implements OnModuleInit {
       columnNames,
     );
     await this.deleteFile(csvFilePath);
+
+    this.usageService.updateRowCount(sid);
 
     return {
       status: result.affectedRows === recordDto.count,

--- a/BE/src/usage/dto/res-usage.dto.ts
+++ b/BE/src/usage/dto/res-usage.dto.ts
@@ -1,0 +1,17 @@
+import { Expose } from 'class-transformer';
+
+export class ResUsageDto {
+  /**
+   * 사용중인 row 수
+   * @example 100
+   */
+  @Expose()
+  currentUsage: number;
+
+  /**
+   * 사용가능한 최대 row 수
+   * @example 10000
+   */
+  @Expose()
+  availUsage: number;
+}

--- a/BE/src/usage/usage.controller.ts
+++ b/BE/src/usage/usage.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Req, UseFilters } from '@nestjs/common';
+import { UsageService } from './usage.service';
+import { Request } from 'express';
+import { ExceptionHandler } from 'src/common/exception/exception.handler';
+import { ApiExtraModels } from '@nestjs/swagger';
+import { ResUsageDto } from './dto/res-usage.dto';
+import { Serialize } from 'src/interceptors/serialize.interceptor';
+
+@Controller('/api/usage')
+@ApiExtraModels(ResUsageDto)
+@UseFilters(new ExceptionHandler())
+export class UsageController {
+  constructor(private readonly usageService: UsageService) {}
+  @Get()
+  @Serialize(ResUsageDto)
+  async getUsage(@Req() req: Request) {
+    const sessionId = req.sessionID;
+    return this.usageService.getRowCount(sessionId);
+  }
+}

--- a/BE/src/usage/usage.service.ts
+++ b/BE/src/usage/usage.service.ts
@@ -1,0 +1,61 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { RowDataPacket } from 'mysql2';
+import { QueryDBAdapter } from 'src/config/query-database/query-db.adapter';
+import { QUERY_DB_ADAPTER } from 'src/config/query-database/query-db.moudle';
+
+@Injectable()
+export class UsageService {
+  MAX_ROW_COUNT = 10;
+  constructor(
+    @Inject(QUERY_DB_ADAPTER) private readonly queryDBAdapter: QueryDBAdapter,
+  ) {}
+
+  public async getRowCount(identify: string) {
+    const tableList = await this.getTableList(identify);
+    console.log('tables', tableList);
+    if (tableList.length === 0) {
+      return {
+        currentUsage: 0,
+        availUsage: this.MAX_ROW_COUNT,
+      };
+    }
+
+    const query = this.createSumQuery(tableList);
+    const result = await this.queryDBAdapter.run(query);
+    const rowCount = parseInt(result[0].total_rows, 10);
+    return {
+      currentUsage: rowCount,
+      availUsage: this.MAX_ROW_COUNT,
+    };
+  }
+
+  public async getTableList(identify: string) {
+    const getTabelListQuery = `SELECT GROUP_CONCAT(TABLE_NAME) AS table_name
+      FROM information_schema.tables
+      WHERE table_schema = '${identify}'
+      AND TABLE_TYPE = 'BASE TABLE';`;
+
+    const [tableList] = await this.queryDBAdapter
+      .getAdminPool()
+      .query<RowDataPacket[]>(getTabelListQuery);
+    console.log('tableList', tableList);
+    const tableNameList = tableList[0].table_name.split(',');
+    return tableNameList;
+  }
+
+  private createSumQuery(tableNameList: any[]): string {
+    const unionQueries = tableNameList
+      .map(
+        (tableName) =>
+          `SELECT '${tableName}' AS table_name, COUNT(*) AS row_count FROM ${tableName}`,
+      )
+      .join(' UNION ALL ');
+
+    return `
+      SELECT SUM(row_count) AS total_rows
+      FROM (
+        ${unionQueries}
+      ) AS combined_counts;
+    `;
+  }
+}

--- a/BE/src/usage/useage.module.ts
+++ b/BE/src/usage/useage.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { UsageController } from './usage.controller';
+import { UsageService } from './usage.service';
+import { QueryDBModule } from 'src/config/query-database/query-db.moudle';
+
+@Module({
+  imports: [QueryDBModule],
+  controllers: [UsageController],
+  providers: [UsageService],
+})
+export class UsageModule {}

--- a/BE/src/usage/useage.module.ts
+++ b/BE/src/usage/useage.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { UsageController } from './usage.controller';
 import { UsageService } from './usage.service';
 import { QueryDBModule } from 'src/config/query-database/query-db.moudle';
+import { RedisService } from 'src/config/redis/redis.service';
 
 @Module({
   imports: [QueryDBModule],
   controllers: [UsageController],
-  providers: [UsageService],
+  providers: [UsageService, RedisService],
+  exports: [UsageService],
 })
 export class UsageModule {}


### PR DESCRIPTION
close #157 
## 📝 기능 설명
<!-- 제안하는 기능에 대해 명확하고 간단히 설명해주세요 -->
사용자가 생성한 테이블들의 row 수를 모두 더해서 데이터 용량을 조회합니다.

## 🛠 작업 사항
<!-- 구현한 작업 내용을 설명해주세요 -->
/api/usage 로 현재 row수를 조회할 수 있습니다.
쿼리를 실행시키거나 랜덤 데이터를 생성하면 쿼리를 날려 사용자의 전체 row수를 갱신합니다. 그리고 갱신된 값은 redis에 저장합니다.

## ✅ 작업 체크리스트
- [x] /api/usage 로 현재 row수를 조회
- [x] redis에 row수 저장 및 갱신

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
redis에 저장되는 값
<img width="890" alt="image" src="https://github.com/user-attachments/assets/58e2c2d9-55bb-4f40-87ba-a4dd0e740c69">