### PR TITLE
[#111] 랜덤 데이터 로직 추가

### DIFF
--- a/FE/src/components/InputWithLocalState.tsx
+++ b/FE/src/components/InputWithLocalState.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+
+type InputWithLocalStateProps<T> =
+  React.InputHTMLAttributes<HTMLInputElement> & {
+    value: T
+    onChange: (value: T) => void
+  }
+
+export default function InputWithLocalState<T>({
+  value,
+  onChange,
+  ...props
+}: InputWithLocalStateProps<T>) {
+  const [localValue, setLocalValue] = useState<T>(value)
+
+  const handleBlur = () => {
+    onChange(localValue)
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value
+    setLocalValue(inputValue as T)
+  }
+
+  return (
+    <Input
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+      value={localValue as string}
+      onChange={handleChange}
+      onBlur={handleBlur}
+    />
+  )
+}

--- a/FE/src/components/TagInputForm.tsx
+++ b/FE/src/components/TagInputForm.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import Label from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { generateKey } from '@/util'
+import { X } from 'lucide-react'
+
+type TagInputProps = {
+  type: string
+  preTag: string[]
+  onAdd: (value: string[]) => void
+  // eslint-disable-next-line react/require-default-props
+  children?: React.ReactNode
+}
+
+export default function TagInputForm({
+  type,
+  preTag,
+  onAdd,
+  children,
+}: TagInputProps) {
+  const [inputValue, setInputValue] = useState('')
+  const [tags, setTags] = useState<string[]>(preTag || [])
+
+  const handleAddTag = () => {
+    if (!inputValue.trim() || tags.length >= 10) return
+    setTags((tag) => [...tag, inputValue])
+    setInputValue('')
+  }
+
+  const handleDeleteTag = (tagIdx: number) => {
+    setTags((prevTags) => prevTags.filter((_, index) => index !== tagIdx))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onAdd(tags)
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="grid grid-cols-5 items-center gap-4">
+        <Label htmlFor="enum" className="text-right">
+          {type}
+        </Label>
+        <Input
+          id={type}
+          placeholder={`Write ${type}`}
+          className="col-span-3"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+        />
+        <Button type="button" variant="secondary" onClick={handleAddTag}>
+          Add
+        </Button>
+      </div>
+      {tags.length >= 10 && (
+        <div className="mt-2 flex w-full justify-center">
+          <span className="text-xs text-red-600">
+            Up to 10 tags can be registered.{' '}
+          </span>
+        </div>
+      )}
+      <div className="sticky top-0 min-h-10 items-center gap-3 border-b p-2">
+        {tags?.map((tag, idx) => (
+          <Badge
+            variant="default"
+            className="mr-2 mt-2 cursor-pointer"
+            key={generateKey(tag)}
+          >
+            {tag}
+            <X className="ml-1 w-3" onClick={() => handleDeleteTag(idx)} />
+          </Badge>
+        ))}
+      </div>
+      {children}
+    </form>
+  )
+}

--- a/FE/src/components/TestTool.tsx
+++ b/FE/src/components/TestTool.tsx
@@ -38,7 +38,7 @@ export default function TestQueryTool() {
       <div className="mb-4">
         <p
           id="query-list-label"
-          className="block flex h-10 items-center border-b border-t bg-secondary pl-3 text-sm font-medium text-muted-foreground transition-colors"
+          className="flex h-10 items-center border-b border-t bg-secondary pl-3 text-sm font-medium text-muted-foreground transition-colors"
         >
           Select Query
         </p>
@@ -72,7 +72,7 @@ export default function TestQueryTool() {
 
       {/* Selected Query Display */}
       <div className="mb-4">
-        <div className="mb-3 block flex h-10 items-center justify-between border-b border-t bg-secondary pl-3 text-sm font-medium text-muted-foreground transition-colors">
+        <div className="mb-3 flex h-10 items-center justify-between border-b border-t bg-secondary pl-3 text-sm font-medium text-muted-foreground transition-colors">
           <p id="selected-query-label">Preview / Edit Query</p>
         </div>
 

--- a/FE/src/constants/constants.ts
+++ b/FE/src/constants/constants.ts
@@ -3,6 +3,7 @@ import { Table2, FileText, Network, AlignLeft } from 'lucide-react'
 export const QUERY_KEYS = {
   SHELLS: 'shells',
   TABLES: 'tables',
+  RECORD: 'record',
 } as const
 
 export const MENU_TITLE = {

--- a/FE/src/types/interfaces.ts
+++ b/FE/src/types/interfaces.ts
@@ -45,6 +45,7 @@ export interface TableToolColumnType {
 export interface RecordToolType {
   tableName: string
   columns: RecordToolColumnType[]
+  count: number
 }
 
 export interface RecordToolColumnType {

--- a/FE/src/util.ts
+++ b/FE/src/util.ts
@@ -37,6 +37,7 @@ export function convertTableDataToRecordToolData(
       max: 0,
       enum: [],
     })),
+    count: 0,
   }))
 }
 


### PR DESCRIPTION
## 📝 기능 설명
`랜덤 데이터 추가 요청을 보낸다.` 이슈를 위한 사전작업입니다. 
생각보다 작업이 길어져서 pr을 두번에 걸쳐 올립니다.
랜덤데이터 추가 레이아웃의 입력을 받는 로직을 추가했습니다.

<br>

## 🛠 작업 사항
- 테이블 칼럼별 입력 받는 로직 추가
- number 속성의 경우 min, max값을 입력할 수 있음
- enum 속성의 경우 별도의 창에서 enum을 추가할 수 있음
   - enum은 최대 10개만 입력 가능 : 10개가 되면 안내문구가 뜸
- 전체 row 길이 입력 받기
- generate random data 버튼 클릭시 입력을 객체로 출력

<br>

## 📎 참고 자료

https://github.com/user-attachments/assets/056e25e5-d135-4b2f-b152-a05c622e91b6


