### PR TITLE
[#183, #154] 랜덤 데이터 추가 요청을 보내고 추가 결과를 보여준다.

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-switch": "^1.1.1",
+        "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.3",
         "@tanstack/react-query": "^4.36.1",
         "@vitejs/plugin-react-swc": "^3.5.0",
@@ -1466,6 +1467,39 @@
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "@radix-ui/react-use-previous": "1.1.0",
         "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.2.tgz",
+      "integrity": "sha512-Z6pqSzmAP/bFJoqMAston4eSNa+ud44NSZTiZUmUen+IOZ5nBY8kzuU5WDBVyFXPtcW6yUalOHsxM/BP6Sv8ww==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/FE/package.json
+++ b/FE/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.1",
+    "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tanstack/react-query": "^4.36.1",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/FE/src/api/__mocks__/axiosMock.ts
+++ b/FE/src/api/__mocks__/axiosMock.ts
@@ -2,13 +2,15 @@ import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import mockShells from '@/api/__mocks__/mockShells'
 import mockTables from '@/api/__mocks__/mockTables'
+import mockRecord from '@/api/__mocks__/mockRecord'
 import mockUsage from '@/api/__mocks__/mockUsages'
 
 const axiosMock = axios.create()
 const mock = new MockAdapter(axiosMock)
 
-mockShells(mock) // shells 관련 API 모킹
-mockTables(mock) // tables 관련 API 모킹
+mockShells(mock)
+mockTables(mock)
+mockRecord(mock)
 mockUsage(mock) // usage 관련 API 모킹
 
 export default axiosMock

--- a/FE/src/api/__mocks__/mockRecord.ts
+++ b/FE/src/api/__mocks__/mockRecord.ts
@@ -1,0 +1,5 @@
+import * as MockAdapter from 'axios-mock-adapter'
+
+export default function mockRecord(mock: MockAdapter) {
+  mock.onPost('/record').reply(200, { data: 'success' })
+}

--- a/FE/src/api/__mocks__/mockRecord.ts
+++ b/FE/src/api/__mocks__/mockRecord.ts
@@ -1,5 +1,11 @@
 import * as MockAdapter from 'axios-mock-adapter'
+import { RecordResultType } from '@/types/interfaces'
+
+const recordResult: RecordResultType = {
+  status: true,
+  text: 'randomDataTestTable 에 랜덤 레코드 10개 삽입되었습니다.',
+}
 
 export default function mockRecord(mock: MockAdapter) {
-  mock.onPost('/record').reply(200, { data: 'success' })
+  mock.onPost('/record').reply(200, { data: recordResult })
 }

--- a/FE/src/api/recordApi.ts
+++ b/FE/src/api/recordApi.ts
@@ -1,0 +1,11 @@
+import axiosClient from '@/api/axiosClient'
+import axiosMock from '@/api/__mocks__/axiosMock'
+import { RecordToolType } from '@/types/interfaces'
+
+const axiosInstance =
+  import.meta.env.VITE_NODE_ENV === 'development' ? axiosMock : axiosClient
+
+export default async function addRecord(record: RecordToolType) {
+  const response = await axiosInstance.post('/record', record)
+  return response.data.data
+}

--- a/FE/src/api/recordApi.ts
+++ b/FE/src/api/recordApi.ts
@@ -1,11 +1,13 @@
 import axiosClient from '@/api/axiosClient'
 import axiosMock from '@/api/__mocks__/axiosMock'
-import { RecordToolType } from '@/types/interfaces'
+import { RecordToolType, RecordResultType } from '@/types/interfaces'
 
 const axiosInstance =
   import.meta.env.VITE_NODE_ENV === 'development' ? axiosMock : axiosClient
 
-export default async function addRecord(record: RecordToolType) {
+export default async function addRecord(
+  record: RecordToolType
+): Promise<RecordResultType> {
   const response = await axiosInstance.post('/record', record)
   return response.data.data
 }

--- a/FE/src/components/RecordTool.tsx
+++ b/FE/src/components/RecordTool.tsx
@@ -35,6 +35,7 @@ import {
   TableType,
   RecordToolType,
   RecordToolColumnType,
+  RecordResultType,
 } from '@/types/interfaces'
 import { RECORD_TYPES } from '@/constants/constants'
 import { generateKey, convertTableDataToRecordToolData } from '@/util'
@@ -63,9 +64,8 @@ export default function RecordTool({
     setSelectedTable(recordToolData[0] || { tableName: '', columns: [] })
   }, [tableData])
 
-  const addRecord = async (record: RecordToolType) => {
-    await addRecordMutation.mutateAsync(record)
-  }
+  const addRecord = async (record: RecordToolType): Promise<RecordResultType> =>
+    addRecordMutation.mutateAsync(record)
 
   const handleColumnChange = (
     row: number,
@@ -107,10 +107,10 @@ export default function RecordTool({
 
   const handleSubmitRecord = async () => {
     try {
-      await addRecord(selectedTable)
+      const result: RecordResultType = await addRecord(selectedTable)
       toast({
         title: 'Data inserted successfully',
-        description: `${selectedTable.count} rows inserted successfully in ${selectedTable.tableName} table`,
+        description: result.text,
       })
     } catch (error) {
       toast({

--- a/FE/src/components/RecordTool.tsx
+++ b/FE/src/components/RecordTool.tsx
@@ -108,13 +108,11 @@ export default function RecordTool({
   const handleSubmitRecord = async () => {
     try {
       await addRecord(selectedTable)
-      // console.log('Data inserted successfully', result)
       toast({
         title: 'Data inserted successfully',
         description: `${selectedTable.count} rows inserted successfully in ${selectedTable.tableName} table`,
       })
     } catch (error) {
-      console.error('Failed to insert data:', error)
       toast({
         variant: 'destructive',
         title: 'Failed to insert data',
@@ -251,6 +249,7 @@ export default function RecordTool({
         <Input
           type="number"
           id="Rows"
+          value={selectedTable.count === 0 ? '' : selectedTable.count}
           placeholder="max 100,000"
           className="h-8 w-28 p-2"
           onChange={(e) => handleCountChange(Number(e.target.value))}

--- a/FE/src/components/Shell.tsx
+++ b/FE/src/components/Shell.tsx
@@ -41,17 +41,6 @@ export default function Shell({ shell }: ShellProps) {
     setInputValue(shell.query ?? '')
   }, [shell.query])
 
-  useEffect(() => {
-    const renderer = editorRef.current?.editor.renderer as any
-    if (renderer) {
-      if (!focused) {
-        renderer.$cursorLayer.element.style.display = 'none'
-      } else {
-        renderer.$cursorLayer.element.style.display = ''
-      }
-    }
-  }, [focused])
-
   const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
     if (e.relatedTarget?.id === 'remove-shell-btn') return
     setFocused(false)
@@ -92,7 +81,11 @@ export default function Shell({ shell }: ShellProps) {
             className={`${inputValue.length === 0 ? 'opacity-50' : ''} `}
           />
         </button>
-        <div className="h-full w-full rounded-sm bg-secondary">
+        <div
+          className={`editor-container h-full w-full rounded-sm bg-secondary ${
+            focused ? '' : 'hide-cursor'
+          }`}
+        >
           <style>{`.ace_placeholder {margin: 0;}`}</style>
           <AceEditor
             ref={editorRef}

--- a/FE/src/components/TestTool.tsx
+++ b/FE/src/components/TestTool.tsx
@@ -7,8 +7,11 @@ import 'ace-builds/src-noconflict/theme-monokai'
 import 'ace-builds/src-noconflict/ext-language_tools'
 import testQueries from '@/constants/exampleQuery'
 import { ExampleQuery } from '@/types/interfaces'
+import { useToast } from '@/hooks/use-toast'
 
 export default function TestQueryTool() {
+  const { toast } = useToast()
+
   const { addShell, updateShell } = useShellHandlers()
   const [selectedQuery, setSelectedQuery] = useState<ExampleQuery | null>(null)
   const [queryInput, setQueryInput] = useState<string>('')
@@ -20,7 +23,11 @@ export default function TestQueryTool() {
 
   const handleRunQuery = async () => {
     if (!queryInput) {
-      alert('Please write a query first.')
+      toast({
+        variant: 'destructive',
+        title: 'No query selected',
+        description: 'Please write a query first.',
+      })
       return
     }
 

--- a/FE/src/components/ui/toast.tsx
+++ b/FE/src/components/ui/toast.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import * as ToastPrimitives from '@radix-ui/react-toast'
+import { cva, type VariantProps } from 'class-variance-authority'
+import cn from '@/lib/utils'
+import { Cross2Icon } from '@radix-ui/react-icons'
+
+const ToastProvider = ToastPrimitives.Provider
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      className
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+
+const toastVariants = cva(
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  {
+    variants: {
+      variant: {
+        default: 'border bg-background text-foreground',
+        destructive:
+          'destructive group border-destructive bg-destructive text-destructive-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => (
+  <ToastPrimitives.Root
+    ref={ref}
+    className={cn(toastVariants({ variant }), className)}
+    {...props}
+  />
+))
+Toast.displayName = ToastPrimitives.Root.displayName
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      className
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitives.Action.displayName
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      'absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <Cross2Icon className="h-4 w-4" />
+  </ToastPrimitives.Close>
+))
+ToastClose.displayName = ToastPrimitives.Close.displayName
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn('text-sm font-semibold [&+div]:text-xs', className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitives.Title.displayName
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn('text-sm opacity-90', className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitives.Description.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+}

--- a/FE/src/components/ui/toaster.tsx
+++ b/FE/src/components/ui/toaster.tsx
@@ -1,0 +1,33 @@
+import { useToast } from "@/hooks/use-toast"
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast"
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/FE/src/hooks/use-toast.ts
+++ b/FE/src/hooks/use-toast.ts
@@ -1,0 +1,191 @@
+'use client'
+
+// Inspired by react-hot-toast library
+import * as React from 'react'
+
+import type { ToastActionElement, ToastProps } from '@/components/ui/toast'
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: 'ADD_TOAST',
+  UPDATE_TOAST: 'UPDATE_TOAST',
+  DISMISS_TOAST: 'DISMISS_TOAST',
+  REMOVE_TOAST: 'REMOVE_TOAST',
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType['ADD_TOAST']
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType['UPDATE_TOAST']
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType['DISMISS_TOAST']
+      toastId?: ToasterToast['id']
+    }
+  | {
+      type: ActionType['REMOVE_TOAST']
+      toastId?: ToasterToast['id']
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: 'REMOVE_TOAST',
+      toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'ADD_TOAST':
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case 'UPDATE_TOAST':
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case 'DISMISS_TOAST': {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      }
+    }
+    case 'REMOVE_TOAST':
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, 'id'>
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: 'UPDATE_TOAST',
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: 'DISMISS_TOAST', toastId: id })
+
+  dispatch({
+    type: 'ADD_TOAST',
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: 'DISMISS_TOAST', toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/FE/src/hooks/useRecordQuery.ts
+++ b/FE/src/hooks/useRecordQuery.ts
@@ -1,11 +1,18 @@
-import useCustomMutation from '@/hooks/useCustomMutation'
+import { useMutation, useQueryClient } from 'react-query'
 import addRecord from '@/api/recordApi'
-import { RecordToolType } from '@/types/interfaces'
+import { RecordToolType, RecordResultType } from '@/types/interfaces'
 import { QUERY_KEYS } from '@/constants/constants'
 
 export default function useAddRecord() {
-  return useCustomMutation<RecordToolType, RecordToolType>(
-    addRecord,
-    QUERY_KEYS.RECORD
-  )
+  const queryClient = useQueryClient()
+
+  return useMutation<RecordResultType, Error, RecordToolType>({
+    mutationFn: addRecord,
+    onSuccess: () => {
+      queryClient.invalidateQueries(QUERY_KEYS.RECORD)
+    },
+    onError: (error) => {
+      console.error('Error inserting record:', error)
+    },
+  })
 }

--- a/FE/src/hooks/useRecordQuery.ts
+++ b/FE/src/hooks/useRecordQuery.ts
@@ -1,0 +1,11 @@
+import useCustomMutation from '@/hooks/useCustomMutation'
+import addRecord from '@/api/recordApi'
+import { RecordToolType } from '@/types/interfaces'
+import { QUERY_KEYS } from '@/constants/constants'
+
+export default function useAddRecord() {
+  return useCustomMutation<RecordToolType, RecordToolType>(
+    addRecord,
+    QUERY_KEYS.RECORD
+  )
+}

--- a/FE/src/pages/MainPage.tsx
+++ b/FE/src/pages/MainPage.tsx
@@ -7,6 +7,7 @@ import ShellList from '@/components/ShellList'
 import { useShells } from '@/hooks/useShellQuery'
 import { useTables } from '@/hooks/useTableQuery'
 import useUsages from '@/hooks/useUsageQuery'
+import { Toaster } from '@/components/ui/toaster'
 
 export default function Page() {
   const {
@@ -19,14 +20,14 @@ export default function Page() {
     isLoading: isTablesLoading,
     error: tablesError,
   } = useTables()
-  const { data: usage } = useUsages()
+  const { data: usage = { availUsage: 0, currentUsage: 0 } } = useUsages()
   const [activeItem, setActiveItem] = useState(MENU[0])
 
   return (
     <SidebarProvider
       style={
         {
-          '--sidebar-width': '350px',
+          '--sidebar-width': '400px',
         } as React.CSSProperties
       }
     >
@@ -46,6 +47,7 @@ export default function Page() {
         )}
       </SidebarInset>
       {!isTablesLoading && !tablesError && <RightSidebar tables={tables} />}
+      <Toaster />
     </SidebarProvider>
   )
 }

--- a/FE/src/types/interfaces.ts
+++ b/FE/src/types/interfaces.ts
@@ -62,6 +62,11 @@ export interface RecordToolColumnType {
   enum: string[]
 }
 
+export interface RecordResultType {
+  status: boolean
+  text: string
+}
+
 export type QueryType =
   | 'SELECT'
   | 'INSERT'

--- a/FE/src/util.ts
+++ b/FE/src/util.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import { TableType, TableToolType, RecordToolType } from '@/types/interfaces'
+import { COLUMN_TYPES } from '@/constants/constants'
 
 export function generateKey(data: Record<string, unknown> | unknown) {
   if (data !== null && typeof data === 'object' && 'id' in data)
@@ -10,9 +11,10 @@ export function generateKey(data: Record<string, unknown> | unknown) {
 export function convertTableDataToTableToolData(
   tableData: TableType[]
 ): TableToolType[] {
-  const isVarchar = (type: string) => {
-    const upperCaseType = type.toUpperCase()
-    return /VARCHAR/i.test(upperCaseType) ? 'VARCHAR(255)' : upperCaseType
+  const getNormalizedType = (value: string): string => {
+    const baseType = value.toUpperCase().split('(')[0]
+    const matchedType = COLUMN_TYPES.find((type) => type.startsWith(baseType))
+    return matchedType ?? value
   }
 
   return tableData.map((table) => ({
@@ -20,7 +22,7 @@ export function convertTableDataToTableToolData(
     columns: table.columns.map((column) => ({
       id: uuidv4(),
       name: column.name,
-      type: isVarchar(column.type),
+      type: getNormalizedType(column.type),
       PK: column.PK,
       UQ: column.UQ,
       AI: column.AI,

--- a/FE/src/util.ts
+++ b/FE/src/util.ts
@@ -10,12 +10,17 @@ export function generateKey(data: Record<string, unknown> | unknown) {
 export function convertTableDataToTableToolData(
   tableData: TableType[]
 ): TableToolType[] {
+  const isVarchar = (type: string) => {
+    const upperCaseType = type.toUpperCase()
+    return /VARCHAR/i.test(upperCaseType) ? 'VARCHAR(255)' : upperCaseType
+  }
+
   return tableData.map((table) => ({
     tableName: table.tableName,
     columns: table.columns.map((column) => ({
       id: uuidv4(),
       name: column.name,
-      type: column.type,
+      type: isVarchar(column.type),
       PK: column.PK,
       UQ: column.UQ,
       AI: column.AI,


### PR DESCRIPTION
## 📝 기능 설명
- 랜덤 데이터 추가 요청 함수 및 모킹함수 추가
- 요청 결과에 따라 토스트를 띄워줌

<div>

## 🛠 중요 작업 사항
- 랜덤 데이터 추가 요청 함수 구현
- 랜덤 데이터 추가 요청 모킹
- 요청 실패시 실패 토스트 띄우기
- 요청 성공시 성공 토스트 띄우기

## 🛠 서브 작업 사항
- 예시 쿼리 기능의 alert 토스트로 변경

<div>

## 📎 참고 자료
- 요청 성공시
![성공](https://github.com/user-attachments/assets/63189e02-7aaf-42f0-81f4-3f77b008f279)

<div>

- 요청 실패시
![실패](https://github.com/user-attachments/assets/a6bf87b7-f2cf-40d7-84d0-884711b00fd1)
<div>
