### PR TITLE
[#191] record service 에서 csvTemp 폴더를 생성하지 못하는 문제를 해결

### DIFF
--- a/BE/src/record/record-initialize.service.ts
+++ b/BE/src/record/record-initialize.service.ts
@@ -1,0 +1,18 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import fs from 'fs/promises';
+import { RANDOM_DATA_TEMP_DIR } from './constant/random-record.constant';
+
+@Injectable()
+export class RecordInitializeService implements OnModuleInit {
+  async onModuleInit() {
+    try {
+      await fs.access(RANDOM_DATA_TEMP_DIR);
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        await fs.mkdir(RANDOM_DATA_TEMP_DIR, { recursive: true });
+      } else {
+        console.error('csv 폴더 접근 오류: ', err);
+      }
+    }
+  }
+}

--- a/BE/src/record/record.module.ts
+++ b/BE/src/record/record.module.ts
@@ -4,10 +4,11 @@ import { RecordService } from './record.service';
 import { RedisModule } from '../config/redis/redis.module';
 import { UserDBManager } from '../config/query-database/user-db-manager.service';
 import { UsageModule } from '../usage/usage.module';
+import { RecordInitializeService } from './record-initialize.service';
 
 @Module({
   imports: [RedisModule, UsageModule],
   controllers: [RecordController],
-  providers: [RecordService, UserDBManager],
+  providers: [RecordService, UserDBManager, RecordInitializeService],
 })
 export class RecordModule {}

--- a/BE/src/record/record.service.ts
+++ b/BE/src/record/record.service.ts
@@ -1,7 +1,7 @@
 import {
   Injectable,
   InternalServerErrorException,
-  OnModuleInit,
+  Scope,
 } from '@nestjs/common';
 import { EnumGenerator, NumberGenerator, RandomValueGenerator } from './domain';
 import {
@@ -22,21 +22,9 @@ import {
   TypeToConstructor,
 } from './constant/random-record.constant';
 
-@Injectable()
-export class RecordService implements OnModuleInit {
+@Injectable({ scope: Scope.DEFAULT })
+export class RecordService {
   constructor(private readonly userDBManager: UserDBManager) {}
-
-  async onModuleInit() {
-    try {
-      await fs.access(RANDOM_DATA_TEMP_DIR);
-    } catch (err) {
-      if (err.code === 'ENOENT') {
-        await fs.mkdir(RANDOM_DATA_TEMP_DIR, { recursive: true });
-      } else {
-        console.error('csv 폴더 접근 오류: ', err);
-      }
-    }
-  }
 
   async insertRandomRecord(
     createRandomRecordDto: CreateRandomRecordDto,


### PR DESCRIPTION
## 📝 기능 설명
<!-- 제안하는 기능에 대해 명확하고 간단히 설명해주세요 -->
record service 에서 OnModuleInit 이 호출되지 않는 문제

스코프 전파로 인해 UserDBManager 객체를 의존성으로 갖는 모든 컨트롤러와 서비스가 Request 스코프로 동작합니다.

## 🛠 작업 사항
<!-- 구현한 작업 내용을 설명해주세요 -->
csvTemp 폴더 생성을 담당할 `RecordInitializeService` 클래스를 추가해 주었습니다.
싱글톤으로 동작하며, 모듈 초기화 시 csvTemp 폴더를 확인하고 생성합니다.

```javascript
import { Injectable, OnModuleInit } from '@nestjs/common';
import fs from 'fs/promises';
import { RANDOM_DATA_TEMP_DIR } from './constant/random-record.constant';

@Injectable()
export class RecordInitializeService implements OnModuleInit {
  async onModuleInit() {
    try {
      await fs.access(RANDOM_DATA_TEMP_DIR);
    } catch (err) {
      if (err.code === 'ENOENT') {
        await fs.mkdir(RANDOM_DATA_TEMP_DIR, { recursive: true });
      } else {
        console.error('csv 폴더 접근 오류: ', err);
      }
    }
  }
}
```
## ✅ 작업 체크리스트
- [x] temp 폴더 생성 담당할 클래스 구현

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
