### PR TITLE
[#21, #22] 결과테이블을 10개씩 보여주고, +버튼을 통해 10개씩 추가 추가한다.

### DIFF
--- a/FE/src/components/ResultTable.tsx
+++ b/FE/src/components/ResultTable.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+import { generateKey } from '@/util'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './ui/table'
+
+function ResultTable({ data }: { data: any[] }) {
+  const ITEMS_PER_PAGE = 10
+
+  const [visibleCount, setVisibleCount] = useState(ITEMS_PER_PAGE)
+  const visibleData = data.slice(0, visibleCount)
+
+  const handleLoadMore = () => {
+    setVisibleCount((prevCount) => prevCount + ITEMS_PER_PAGE)
+  }
+
+  return (
+    <div className="w-full">
+      <Table className="">
+        <TableHeader>
+          <TableRow>
+            {Object.keys(data[0]).map((header) => (
+              <TableHead
+                className="border-b border-t text-muted-foreground"
+                key={header}
+              >
+                {header}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {visibleData.map((row) => (
+            <TableRow key={generateKey(row)}>
+              {Object.values(row).map((cell) => (
+                <TableCell key={generateKey(cell)}>{String(cell)}</TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {visibleCount < data.length && (
+        <button
+          type="button"
+          className="mt-3 flex w-full justify-center bg-primary"
+          onClick={handleLoadMore}
+        >
+          <div className="text-bold w-3 text-background">+</div>
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default ResultTable

--- a/FE/src/components/ResultTable.tsx
+++ b/FE/src/components/ResultTable.tsx
@@ -26,7 +26,7 @@ function ResultTable({ data }: { data: any[] }) {
           <TableRow>
             {Object.keys(data[0]).map((header) => (
               <TableHead
-                className="border-b border-t text-muted-foreground"
+                className="border-b border-t border-gray-300 text-muted-foreground"
                 key={header}
               >
                 {header}
@@ -36,7 +36,10 @@ function ResultTable({ data }: { data: any[] }) {
         </TableHeader>
         <TableBody>
           {visibleData.map((row) => (
-            <TableRow key={generateKey(row)}>
+            <TableRow
+              className="border-b border-t border-gray-300"
+              key={generateKey(row)}
+            >
               {Object.values(row).map((cell) => (
                 <TableCell key={generateKey(cell)}>{String(cell)}</TableCell>
               ))}

--- a/FE/src/components/Shell.tsx
+++ b/FE/src/components/Shell.tsx
@@ -2,22 +2,14 @@ import { useState, useRef, useEffect } from 'react'
 import PlayCircle from '@/assets/play_circle.svg'
 import { ShellType } from '@/types/interfaces'
 import useShellHandlers from '@/hooks/useShellHandler'
-import { generateKey } from '@/util'
 import { X } from 'lucide-react'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
 import { useTables } from '@/hooks/useTableQuery'
 import AceEditor from 'react-ace'
 import 'ace-builds/src-noconflict/mode-sql'
 import 'ace-builds/src-noconflict/theme-monokai'
 import 'ace-builds/src-noconflict/ext-language_tools'
 import useUsages from '@/hooks/useUsageQuery'
+import ResultTable from './ResultTable'
 
 type ShellProps = {
   shell: ShellType
@@ -144,39 +136,9 @@ export default function Shell({ shell }: ShellProps) {
           >
             {text}
           </p>
-          {resultTable &&
-            resultTable?.length > 0 && ( // 결과 테이블이 있는지
-              <>
-                <Table className="m-3">
-                  <TableHeader>
-                    <TableRow>
-                      {Object.keys(resultTable[0])?.map((header) => (
-                        <TableHead key={generateKey(header)}>
-                          {header}
-                        </TableHead>
-                      ))}
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {resultTable.map((row) => (
-                      <TableRow key={generateKey(row)}>
-                        {Object.values(row).map((cell) => (
-                          <TableCell key={generateKey(cell)}>
-                            {String(cell)}
-                          </TableCell>
-                        ))}
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-                <button
-                  type="button"
-                  className="flex w-full justify-center bg-primary"
-                >
-                  <div className="text-bold w-3 text-background">+</div>
-                </button>
-              </>
-            )}
+          {resultTable && resultTable?.length > 0 && (
+            <ResultTable data={resultTable} />
+          )}
         </div>
       )}
     </>


### PR DESCRIPTION
## 📝 기능 설명
<!-- 제안하는 기능에 대해 명확하고 간단히 설명해주세요 -->
결과 테이블을 보여줍니다.

## 🛠 작업 사항
<!-- 구현한 작업 내용을 설명해주세요 -->
결과테이블이 존재한다면 10개를 보여줍니다.
+ 버튼을 통해 테입블에 10개씩 추가합니다.
테이블 디자인 추천받습니다. 테이블 헤더에 색깔 넣어주고 싶은데 어떤색깔이 좋을지 고민 중 입니다.

## ✅ 작업 체크리스트
- [x] ResultTable 컴포넌트 분리
- [x] 테이블 좌우 스크롤 바 생기던 것 수정

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
![ezgif-1-4bc3b60e62](https://github.com/user-attachments/assets/d555df5b-7fdc-43c9-9408-6fbd1ae84112)

