### PR TITLE
[#204] 프론트 에러핸들링 구현

### DIFF
--- a/FE/src/api/__mocks__/mockRecord.ts
+++ b/FE/src/api/__mocks__/mockRecord.ts
@@ -3,9 +3,19 @@ import { RecordResultType } from '@/types/interfaces'
 
 const recordResult: RecordResultType = {
   status: true,
-  text: 'randomDataTestTable 에 랜덤 레코드 10개 삽입되었습니다.',
+  text: '10 records successfully insterted into randomDataTestTable Table.',
 }
 
 export default function mockRecord(mock: MockAdapter) {
-  mock.onPost('/record').reply(200, { data: recordResult })
+  mock.onPost('/record').reply((config) => {
+    if (Math.random() < 0.2) {
+      return [429, { error: { message: 'connection too many Error.' } }]
+    }
+
+    if (Math.random() < 0.2) {
+      return [430, { error: { message: 'usage limit exceed error.' } }]
+    }
+
+    return [200, { data: recordResult }]
+  })
 }

--- a/FE/src/api/__mocks__/mockShells.ts
+++ b/FE/src/api/__mocks__/mockShells.ts
@@ -27,6 +27,15 @@ export default function mockShells(mock: MockAdapter) {
     const result = getMocResult(executeddShell)
 
     shellData.splice(index, 1, { ...executeddShell, ...result })
+
+    if (Math.random() < 0.2) {
+      return [429, { error: { message: 'connection too many Error.' } }]
+    }
+
+    if (Math.random() < 0.2) {
+      return [430, { error: { message: 'usage limit exceed error.' } }]
+    }
+
     return [200, { data: result }]
   })
 

--- a/FE/src/components/RecordTool.tsx
+++ b/FE/src/components/RecordTool.tsx
@@ -106,19 +106,11 @@ export default function RecordTool({
   }
 
   const handleSubmitRecord = async () => {
-    try {
-      const result: RecordResultType = await addRecord(selectedTable)
-      toast({
-        title: 'Data inserted successfully',
-        description: result.text,
-      })
-    } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Failed to insert data',
-        description: `${selectedTable.count} rows failed to insert in ${selectedTable.tableName} table`,
-      })
-    }
+    const result: RecordResultType = await addRecord(selectedTable)
+    toast({
+      title: 'Data inserted successfully',
+      description: result.text,
+    })
   }
 
   return (

--- a/FE/src/error/toastErrorHandler.ts
+++ b/FE/src/error/toastErrorHandler.ts
@@ -17,7 +17,7 @@ export default function useToastErrorHandler() {
             error.response?.data?.error?.message ||
             'The server is currently handling too many requests. Please try again later.'
           break
-        case 430:
+        case 422:
           title = 'Usage Limit Exceeded'
           description =
             error.response?.data?.error?.message ||

--- a/FE/src/error/toastErrorHandler.ts
+++ b/FE/src/error/toastErrorHandler.ts
@@ -1,0 +1,47 @@
+import { useToast } from '@/hooks/use-toast'
+import { AxiosError } from 'axios'
+
+export default function useToastErrorHandler() {
+  const { toast } = useToast()
+
+  return (error: AxiosError | Error) => {
+    let title
+    let description
+
+    if ('isAxiosError' in error && error.isAxiosError) {
+      const status = error.response?.status
+      switch (status) {
+        case 429:
+          title = 'Server Connection Limit Exceeded'
+          description =
+            error.response?.data?.error?.message ||
+            'The server is currently handling too many requests. Please try again later.'
+          break
+        case 430:
+          title = 'Usage Limit Exceeded'
+          description =
+            error.response?.data?.error?.message ||
+            'You have exceeded your usage limit. Please delete rows or tables and try again.'
+          break
+        default:
+          console.error('Unhandled AxiosError:', error)
+          title = `Error ${status || 'Unknown'}`
+          description =
+            error.response?.data?.error?.message || 'An unknown error occurred.'
+      }
+    } else {
+      console.error('Unhandled Error:', error)
+      title = 'An unexpected error occurred'
+      message =
+        error.message ||
+        error.response?.data?.error?.message ||
+        'Please try again later.'
+    }
+
+    toast({
+      variant: 'destructive',
+      title,
+      description,
+    })
+  }
+}

--- a/FE/src/hooks/use-toast.ts
+++ b/FE/src/hooks/use-toast.ts
@@ -72,6 +72,7 @@ const addToRemoveQueue = (toastId: string) => {
 }
 
 export const reducer = (state: State, action: Action): State => {
+  // eslint-disable-next-line default-case
   switch (action.type) {
     case 'ADD_TOAST':
       return {

--- a/FE/src/hooks/useCustomMutation.ts
+++ b/FE/src/hooks/useCustomMutation.ts
@@ -1,4 +1,5 @@
 import { useMutation, UseMutationOptions, useQueryClient } from 'react-query'
+import useToastErrorHandler from '@/error/toastErrorHandler'
 
 type MutationContext<TData> = {
   previousData: TData[] | undefined
@@ -10,6 +11,7 @@ export default function useCustomMutation<TData, TVariables extends TData>(
   options?: UseMutationOptions<TData, Error, TVariables, MutationContext<TData>>
 ) {
   const queryClient = useQueryClient()
+  const handleErrorHandler = useToastErrorHandler()
 
   return useMutation<TData, Error, TVariables, MutationContext<TData>>(
     mutationFn,
@@ -25,7 +27,7 @@ export default function useCustomMutation<TData, TVariables extends TData>(
         if (context?.previousData) {
           queryClient.setQueryData(queryKey, context.previousData)
         }
-        console.error(error)
+        handleErrorHandler(error)
       },
       ...options,
     }

--- a/FE/src/hooks/useRecordQuery.ts
+++ b/FE/src/hooks/useRecordQuery.ts
@@ -2,10 +2,11 @@ import { useMutation, useQueryClient } from 'react-query'
 import addRecord from '@/api/recordApi'
 import { RecordToolType, RecordResultType } from '@/types/interfaces'
 import { QUERY_KEYS } from '@/constants/constants'
+import useToastErrorHandler from '@/error/toastErrorHandler'
 
 export default function useAddRecord() {
+  const handleToastError = useToastErrorHandler()
   const queryClient = useQueryClient()
-
   return useMutation<RecordResultType, Error, RecordToolType>({
     mutationFn: addRecord,
     onSuccess: () => {
@@ -13,6 +14,7 @@ export default function useAddRecord() {
     },
     onError: (error) => {
       console.error('Error inserting record:', error)
+      handleToastError(error)
     },
   })
 }


### PR DESCRIPTION
## 📝 기능 설명
<!-- 제안하는 기능에 대해 명확하고 간단히 설명해주세요 -->
서버 요청 후 에러를 받을 시 toast 로 화면에 띄워줍니다.

## 🛠 작업 사항
<!-- 구현한 작업 내용을 설명해주세요 -->
429: 서버 커넥션 초과인 경우
422: 사용자 사용량 초과인 경우
공통 에러 핸들링을 위한 toastErrorHandler 훅 구현
목데이터 요청 시 각 20% 확률로 429, 422 에러를 반환합니다.

## ✅ 작업 체크리스트
- [x] 목데이터 에러 반환하도록 변경
- [x] 에러 핸들링을 위한 toastErrorHandler 훅 구현
- [x] 쿼리 실행과 랜덤 데이터 추가 api 에 에러 핸들러 등록

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->

![](https://s1.ezgif.com/tmp/ezgif-1-057af36e60.gif)

