### PR TITLE
[#218] 랜덤 데이터 추가 요청에 대한 검증 로직 추가

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -33,7 +33,8 @@
         "typeorm": "^0.3.20",
         "uuid": "^11.0.2",
         "winston": "^3.17.0",
-        "winston-daily-rotate-file": "^5.0.0"
+        "winston-daily-rotate-file": "^5.0.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",
@@ -13094,6 +13095,14 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/BE/package.json
+++ b/BE/package.json
@@ -44,7 +44,8 @@
     "typeorm": "^0.3.20",
     "uuid": "^11.0.2",
     "winston": "^3.17.0",
-    "winston-daily-rotate-file": "^5.0.0"
+    "winston-daily-rotate-file": "^5.0.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/BE/src/common/exception/exception.handler.ts
+++ b/BE/src/common/exception/exception.handler.ts
@@ -11,7 +11,7 @@ export class ExceptionHandler implements ExceptionFilter {
   catch(error: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse();
-
+    console.log(error);
     const status =
       error instanceof HttpException
         ? error.getStatus()

--- a/BE/src/common/exception/exception.handler.ts
+++ b/BE/src/common/exception/exception.handler.ts
@@ -11,7 +11,6 @@ export class ExceptionHandler implements ExceptionFilter {
   catch(error: Error, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse();
-    console.log(error);
     const status =
       error instanceof HttpException
         ? error.getStatus()

--- a/BE/src/interceptors/serialize.interceptor.ts
+++ b/BE/src/interceptors/serialize.interceptor.ts
@@ -7,6 +7,8 @@ import {
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { plainToInstance } from 'class-transformer';
+import { catchError } from 'rxjs/operators';
+import { throwError } from 'rxjs';
 
 interface ClassConstructor<T> {
   new (...args: any[]): T;
@@ -23,6 +25,9 @@ class SerializeInterceptor<T> implements NestInterceptor {
     next: CallHandler<any>,
   ): Observable<any> {
     return next.handle().pipe(
+      catchError((error) => {
+        return throwError(() => error);
+      }),
       map((inputData: any) => {
         let data;
         if (inputData instanceof Array) {
@@ -51,6 +56,7 @@ class SerializeInterceptor<T> implements NestInterceptor {
   }
 
   removeNullProperties(obj: any): any {
+    if (!obj) return;
     return Object.fromEntries(
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       Object.entries(obj).filter(([_, value]) => value !== null),

--- a/BE/src/interceptors/user-db-connection.interceptor.ts
+++ b/BE/src/interceptors/user-db-connection.interceptor.ts
@@ -55,10 +55,9 @@ export class UserDBConnectionInterceptor implements NestInterceptor {
         await request.dbConnection.commit();
       }),
       catchError(async (err) => {
-        if (err instanceof DataLimitExceedException) {
+        if (err instanceof DataLimitExceedException)
           await request.dbConnection.rollback();
-          throw err;
-        }
+        throw err;
       }),
       finalize(async () => await request.dbConnection.end()),
     );

--- a/BE/src/record/constant/random-record.constant.ts
+++ b/BE/src/record/constant/random-record.constant.ts
@@ -30,3 +30,34 @@ export const TypeToConstructor = {
   sex: SexGenerator,
   boolean: BooleanGenerator,
 };
+
+export const DomainToTypes = {
+  name: 'string',
+  country: 'string',
+  city: 'string',
+  email: 'string',
+  phone: 'string',
+  sex: 'string',
+  boolean: 'number',
+  number: 'number',
+  enum: 'string',
+};
+
+export const mysqlToJsType = (mysqlType: string): string => {
+  const baseType = mysqlType.split('(')[0];
+  const typeMap: Record<string, string> = {
+    VARCHAR: 'string',
+    CHAR: 'string',
+    TEXT: 'string',
+    INT: 'number',
+    TINYINT: 'number',
+    BIGINT: 'number',
+    FLOAT: 'number',
+    DOUBLE: 'number',
+    DECIMAL: 'number',
+    DATETIME: 'string',
+    DATE: 'string',
+    TIMESTAMP: 'string',
+  };
+  return typeMap[baseType.toUpperCase()] || 'unknown';
+};

--- a/BE/src/record/random-column.entity.ts
+++ b/BE/src/record/random-column.entity.ts
@@ -1,7 +1,7 @@
 import { Domains } from './dto/create-random-record.dto';
 import { RandomValueGenerator } from './domain';
 
-export interface RandomColumnEntity {
+export interface RandomColumnModel {
   name: string;
   type: Domains;
   generator: RandomValueGenerator<any>;

--- a/BE/src/record/record.controller.ts
+++ b/BE/src/record/record.controller.ts
@@ -19,10 +19,11 @@ export class RecordController {
   @ExecuteRecordSwagger()
   @Serialize(ResRecordDto)
   @Post()
-  insertRandomRecord(
+  async insertRandomRecord(
     @Req() req: Request,
     @Body() randomRecordInsertDto: CreateRandomRecordDto,
   ) {
+    await this.recordService.validateDto(randomRecordInsertDto, req.sessionID);
     return this.recordService.insertRandomRecord(req, randomRecordInsertDto);
   }
 }

--- a/BE/src/record/record.module.ts
+++ b/BE/src/record/record.module.ts
@@ -4,9 +4,10 @@ import { RecordService } from './record.service';
 import { RedisModule } from '../config/redis/redis.module';
 import { QueryDBModule } from '../config/query-database/query-db.moudle';
 import { UsageModule } from '../usage/usage.module';
+import { TableModule } from 'src/table/table.module';
 
 @Module({
-  imports: [RedisModule, QueryDBModule, UsageModule],
+  imports: [RedisModule, QueryDBModule, UsageModule, TableModule],
   controllers: [RecordController],
   providers: [RecordService],
 })

--- a/BE/src/record/record.service.ts
+++ b/BE/src/record/record.service.ts
@@ -54,7 +54,7 @@ export class RecordService implements OnModuleInit {
     createRandomRecordDto: CreateRandomRecordDto,
     identify: string,
   ) {
-    const tableInfo = (await this.tableService.find(
+    const tableInfo: ResTableDto = (await this.tableService.find(
       identify,
       createRandomRecordDto.tableName,
     )) as ResTableDto;
@@ -65,7 +65,7 @@ export class RecordService implements OnModuleInit {
       );
 
     const baseColumns = tableInfo.columns;
-    const columnInfos = createRandomRecordDto.columns;
+    const columnInfos: RandomColumnInfo[] = createRandomRecordDto.columns;
 
     columnInfos.forEach((columnInfo) => {
       const targetName = columnInfo.name;

--- a/BE/src/record/record.service.ts
+++ b/BE/src/record/record.service.ts
@@ -66,8 +66,7 @@ export class RecordService implements OnModuleInit {
 
     const cols = tableInfo.columns;
     const columnInfos = createRandomRecordDto.columns;
-    console.log(cols);
-    //column 이름 확인
+
     columnInfos.forEach((columnInfo) => {
       const targetName = columnInfo.name;
       const targetDomain = columnInfo.type;
@@ -78,8 +77,6 @@ export class RecordService implements OnModuleInit {
           `${targetName} 컬럼이 ${createRandomRecordDto.tableName} 에 존재하지 않습니다.`,
         );
 
-      console.log(mysqlToJsType(baseColumn.type));
-      console.log(DomainToTypes[targetDomain]);
       if (!this.checkDomainAvailability(baseColumn.type, targetDomain))
         throw new BadRequestException(
           `${targetName}(${baseColumn.type}) 컬럼에 ${targetDomain} 랜덤 값을 넣을 수 없습니다.`,

--- a/BE/src/table/table.service.ts
+++ b/BE/src/table/table.service.ts
@@ -18,7 +18,7 @@ export class TableService {
     );
   }
 
-  async find(sessionId: string, tableName: string) {
+  async find(sessionId: string, tableName: string): Promise<ResTableDto | []> {
     const tables = await this.getTables(sessionId, tableName);
     const columns = await this.getColumns(sessionId, tableName);
     const foreignKeys = await this.getForeignKeys(sessionId, tableName);
@@ -45,7 +45,7 @@ export class TableService {
     return tables as any[];
   }
 
-  private async getColumns(schema: string, tableName?: string) {
+  async getColumns(schema: string, tableName?: string) {
     const query = `
     SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, COLUMN_KEY, EXTRA, IS_NULLABLE
     FROM INFORMATION_SCHEMA.COLUMNS

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "ace-builds": "^1.36.5",
-        "react-ace": "^13.0.0"
+        "react-ace": "^13.0.0",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/ace-builds": {
@@ -120,6 +121,14 @@
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "ISC",
   "dependencies": {
     "ace-builds": "^1.36.5",
-    "react-ace": "^13.0.0"
+    "react-ace": "^13.0.0",
+    "zod": "^3.23.8"
   }
 }

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -1,0 +1,14 @@
+import { QueryDto, QueryDtoSchema } from "./query";
+import { RandomColumnInfoSchema, RandomColumnInfo, CreateRandomRecordDto, CreateRandomRecordDtoSchema } from "./record";
+import { UpdateShellDto, UpdateShellDtoSchema } from "./shells";
+
+export {
+  QueryDto,
+  QueryDtoSchema,
+  CreateRandomRecordDto,
+  CreateRandomRecordDtoSchema,
+  RandomColumnInfo,
+  RandomColumnInfoSchema,
+  UpdateShellDto,
+  UpdateShellDtoSchema,
+};

--- a/schemas/query.ts
+++ b/schemas/query.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+// QueryDto 스키마
+export const QueryDtoSchema = z.object({
+  query: z.string(),
+});
+
+// 타입 추론
+export type QueryDto = z.infer<typeof QueryDtoSchema>;

--- a/schemas/record.ts
+++ b/schemas/record.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+// Domains Enum 정의
+const Domains = z.enum(["name", "country", "city", "email", "phone", "sex", "boolean", "number", "enum"]);
+type Domains = z.infer<typeof Domains>;
+
+// RandomColumnInfo 스키마
+export const RandomColumnInfoSchema = z.object({
+  name: z.string().trim().min(1, "Column Name is required"),
+  type: Domains,
+  blank: z.number().int().min(0).max(100, "Blank must be between 0 and 100"),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  enum: z
+    .array(z.string())
+    .max(10, "Enum array can have at most 10 items")
+    .optional()
+    .refine((val) => val === undefined || Array.isArray(val), {
+      message: "Enum must be an array of strings or undefined",
+    }),
+});
+
+// CreateRandomRecordDto 스키마
+export const CreateRandomRecordDtoSchema = z.object({
+  tableName: z.string().trim().min(1, "Table name is required"),
+  columns: z.array(RandomColumnInfoSchema),
+  count: z.number().int().min(1, "Count must be at least 1").max(100000, "Count cannot exceed 100000"),
+});
+
+export type RandomColumnInfo = z.infer<typeof RandomColumnInfoSchema>;
+export type CreateRandomRecordDto = z.infer<typeof CreateRandomRecordDtoSchema>;

--- a/schemas/shells.ts
+++ b/schemas/shells.ts
@@ -1,8 +1,8 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 // UpdateShellDto 스키마
 export const UpdateShellDtoSchema = z.object({
-  query: z.string().nonempty('Query must be a non-empty string'),
+  query: z.string().trim().min(1, "Query must be a non-empty string"),
 });
 
 // 타입 추론

--- a/schemas/shells.ts
+++ b/schemas/shells.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// UpdateShellDto 스키마
+export const UpdateShellDtoSchema = z.object({
+  query: z.string().nonempty('Query must be a non-empty string'),
+});
+
+// 타입 추론
+export type UpdateShellDto = z.infer<typeof UpdateShellDtoSchema>;


### PR DESCRIPTION
## 📝 기능 설명
<!-- 제안하는 기능에 대해 명확하고 간단히 설명해주세요 -->
랜덤 데이터 추가 요청에 대해서 인풋 값을 검증하는 로직을 추가하였습니다.
`mysqlToJsType` 함수 위치가 조금 맘에 안드는데,,, 어디다 둘지 모르겠네요

## 🛠 작업 사항
<!-- 구현한 작업 내용을 설명해주세요 -->
userDBconnection 에서 에러를 잡고 안더지던 문제 수정
에러 필터에서 한번 로깅하도록 수정
serialize 인터셉터에서 에러 잡고 던지도록 수정
랜덤 데이터 api 검증 로직 추가

## ✅ 작업 체크리스트
- [x] 서비스에서 에러를 던졌는데 에러가 디버깅
- [x] 랜덤 데이터 추가 api 요청에 대해 검증 추가

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
