### PR TITLE
[#227] 세션 만료 시간 갱신

### DIFF
--- a/BE/src/config/logger/winston.config.ts
+++ b/BE/src/config/logger/winston.config.ts
@@ -1,6 +1,9 @@
 import { utilities } from 'nest-winston';
 import * as winston from 'winston';
 import 'winston-daily-rotate-file';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
 
 const infoFileOptions = {
   level: 'info',

--- a/BE/src/config/redis/custom-redis-store.ts
+++ b/BE/src/config/redis/custom-redis-store.ts
@@ -13,11 +13,7 @@ export class CustomRedisStore extends Store {
     session: SessionData,
     cb: (err?: any) => void,
   ): Promise<void> {
-    try {
-      return cb();
-    } catch (err) {
-      cb(err);
-    }
+    return cb();
   }
 
   async get(

--- a/BE/src/config/redis/custom-redis-store.ts
+++ b/BE/src/config/redis/custom-redis-store.ts
@@ -14,8 +14,6 @@ export class CustomRedisStore extends Store {
     cb: (err?: any) => void,
   ): Promise<void> {
     try {
-      const ttl = (session.cookie.maxAge / 1000) | (60 * 60); // 기본값: 1시간 (sec)
-      await this.redisService.setExpireTime(sid, ttl);
       return cb();
     } catch (err) {
       cb(err);

--- a/BE/src/config/redis/redis.service.ts
+++ b/BE/src/config/redis/redis.service.ts
@@ -55,6 +55,7 @@ export class RedisService {
       await this.defaultConnection.hset(key, 'rowCount', 0);
       await this.adminDBManager.initUserDatabase(key);
     }
+    await this.setExpireTime(key, 60 * 60);
   }
 
   public async deleteSession(key: string) {

--- a/BE/src/config/redis/redis.service.ts
+++ b/BE/src/config/redis/redis.service.ts
@@ -23,7 +23,7 @@ export class RedisService {
     });
 
     this.defaultConnection.on('ready', () => {
-      this.defaultConnection.config('SET', 'notify-keyspace-events', 'Ex');
+      this.defaultConnection.config('SET', 'notify-keyspace-events', 'Exg');
     });
   }
 
@@ -33,7 +33,7 @@ export class RedisService {
       port: this.configService.get<number>('REDIS_PORT'),
     });
 
-    this.defaultConnection.on('ready', () => {
+    this.eventConnection.on('ready', () => {
       this.subscribeToExpiredEvents();
     });
   }
@@ -67,6 +67,7 @@ export class RedisService {
   }
 
   private subscribeToExpiredEvents() {
+    this.eventConnection.subscribe('__keyevent@0__:del');
     this.eventConnection.subscribe('__keyevent@0__:expired');
 
     this.eventConnection.on('message', (event, session) => {

--- a/BE/src/middleware/session.middleware.ts
+++ b/BE/src/middleware/session.middleware.ts
@@ -20,13 +20,10 @@ export class SessionMiddleware implements NestMiddleware {
       secret: this.configService.get<string>('SESSION_SECRET'),
       resave: false,
       saveUninitialized: true,
-      rolling: true,
       store: new CustomRedisStore(this.redisService),
+      rolling: true,
       genid: () => {
         return 'db' + uuidv4().replace(/[^a-zA-Z0-9]/g, '');
-      },
-      cookie: {
-        maxAge: 1000 * 60 * 60, // 1시간 (ms)
       },
       name: 'sid',
     })(req, res, async () => {


### PR DESCRIPTION
## 📝 기능 설명
<!-- 제안하는 기능에 대해 명확하고 간단히 설명해주세요 -->
특정 세션으로 재접속하는 경우 세션 만료 시간이 갱신되도록 수정하였습니다.

## 🛠 작업 사항
<!-- 구현한 작업 내용을 설명해주세요 -->
express-session에서 작업해주는 쿠키 만료시간을 설정하기 어렵고 확인하기 불편해서... 해당 로직은 제거하였습니다.
그냥 서버에서 redis의 ttl을 설정해주도록 하여 관리합니다.

## ✅ 작업 체크리스트
- [x] 세션 만료 시간 갱신

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
