### PR TITLE
[#225] 로딩 화면을 추가한다

### DIFF
--- a/FE/src/components/LeftSidebar.tsx
+++ b/FE/src/components/LeftSidebar.tsx
@@ -14,27 +14,28 @@ import {
 } from '@/components/ui/sidebar'
 import logo from '@/assets/logo.svg'
 
-import { TableType } from '@/types/interfaces'
 import TableTool from '@/components/TableTool'
 import RecordTool from '@/components/RecordTool'
 import ExampleQueryTool from '@/components/ExampleQueryTool'
 import { ErrorBoundary } from 'react-error-boundary'
 import SidebarErrorPage from '@/pages/SideBarErrorPage'
 import useToastErrorHandler from '@/hooks/error/toastErrorHandler'
+import LoadingPage from '@/pages/LoadingPage'
+import { useTables } from '@/hooks/query/useTableQuery'
 
 type LeftSidebarProps = React.ComponentProps<typeof Sidebar> & {
   activeItem: (typeof MENU)[0]
   setActiveItem: React.Dispatch<React.SetStateAction<(typeof MENU)[0]>>
-  tables: TableType[]
 }
 
 export default function LeftSidebar({
   activeItem,
   setActiveItem,
-  tables,
   ...props
 }: LeftSidebarProps) {
   const menu = MENU.slice(0, -1)
+
+  const tables = useTables()
   const { setOpen, toggleSidebar } = useSidebar()
   const handleError = useToastErrorHandler()
 
@@ -101,39 +102,43 @@ export default function LeftSidebar({
             </button>
           </div>
         </SidebarHeader>
-        <SidebarContent className="h-full">
-          <SidebarGroup className="h-full p-0">
-            <SidebarGroupContent className="h-full">
-              {activeItem.title === MENU_TITLE.TABLE && (
-                <ErrorBoundary
-                  FallbackComponent={SidebarErrorPage}
-                  onReset={() => window.location.reload()}
-                  onError={handleError}
-                >
-                  <TableTool tableData={tables} />
-                </ErrorBoundary>
-              )}
-              {activeItem.title === MENU_TITLE.RECORD && (
-                <ErrorBoundary
-                  FallbackComponent={SidebarErrorPage}
-                  onReset={() => window.location.reload()}
-                  onError={handleError}
-                >
-                  <RecordTool tableData={tables} />
-                </ErrorBoundary>
-              )}
-              {activeItem.title === MENU_TITLE.TESTQUERY && (
-                <ErrorBoundary
-                  FallbackComponent={SidebarErrorPage}
-                  onReset={() => window.location.reload()}
-                  onError={handleError}
-                >
-                  <ExampleQueryTool />
-                </ErrorBoundary>
-              )}
-            </SidebarGroupContent>
-          </SidebarGroup>
-        </SidebarContent>
+        {tables.isLoading ? (
+          <LoadingPage />
+        ) : (
+          <SidebarContent className="h-full">
+            <SidebarGroup className="h-full p-0">
+              <SidebarGroupContent className="h-full">
+                {activeItem.title === MENU_TITLE.TABLE && (
+                  <ErrorBoundary
+                    FallbackComponent={SidebarErrorPage}
+                    onReset={() => window.location.reload()}
+                    onError={handleError}
+                  >
+                    <TableTool tableData={tables.data || []} />
+                  </ErrorBoundary>
+                )}
+                {activeItem.title === MENU_TITLE.RECORD && (
+                  <ErrorBoundary
+                    FallbackComponent={SidebarErrorPage}
+                    onReset={() => window.location.reload()}
+                    onError={handleError}
+                  >
+                    <RecordTool tableData={tables.data || []} />
+                  </ErrorBoundary>
+                )}
+                {activeItem.title === MENU_TITLE.TESTQUERY && (
+                  <ErrorBoundary
+                    FallbackComponent={SidebarErrorPage}
+                    onReset={() => window.location.reload()}
+                    onError={handleError}
+                  >
+                    <ExampleQueryTool />
+                  </ErrorBoundary>
+                )}
+              </SidebarGroupContent>
+            </SidebarGroup>
+          </SidebarContent>
+        )}
       </Sidebar>
     </Sidebar>
   )

--- a/FE/src/components/MainContent.tsx
+++ b/FE/src/components/MainContent.tsx
@@ -4,6 +4,7 @@ import Shell from '@/components/common/shell/Shell'
 import { useShells } from '@/hooks/query/useShellQuery'
 import useUsages from '@/hooks/query/useUsageQuery'
 import useShellHandlers from '@/hooks/useShellHandler'
+import LoadingPage from '@/pages/LoadingPage'
 
 import { ErrorBoundary } from 'react-error-boundary'
 import ShellErrorFallback from './common/shell/ShellErrorFallback'
@@ -34,17 +35,21 @@ export default function MainContent() {
           />
         </div>
       </div>
-      <div className="flex flex-1 flex-col gap-3 p-4">
-        {shells.data?.map((shell) => (
-          <ErrorBoundary
-            key={shell.id}
-            FallbackComponent={ShellErrorFallback}
-            onReset={() => window.location.reload()}
-          >
-            <Shell key={shell.id} shell={shell} />
-          </ErrorBoundary>
-        ))}
-      </div>
+      {shells.isLoading ? (
+        <LoadingPage />
+      ) : (
+        <div className="flex flex-1 flex-col gap-3 p-4">
+          {shells.data?.map((shell) => (
+            <ErrorBoundary
+              key={shell.id}
+              FallbackComponent={ShellErrorFallback}
+              onReset={() => window.location.reload()}
+            >
+              <Shell key={shell.id} shell={shell} />
+            </ErrorBoundary>
+          ))}
+        </div>
+      )}
     </>
   )
 }

--- a/FE/src/components/RightSidebar.tsx
+++ b/FE/src/components/RightSidebar.tsx
@@ -1,5 +1,5 @@
 import { MENU_TITLE } from '@/constants/constants'
-import { TableType } from '@/types/interfaces'
+import { useTables } from '@/hooks/query/useTableQuery'
 import {
   Sidebar,
   SidebarContent,
@@ -7,20 +7,16 @@ import {
   SidebarGroup,
   SidebarGroupContent,
 } from '@/components/ui/sidebar'
+import LoadingPage from '@/pages/LoadingPage'
 import ViewTable from './ViewTable'
 
-export default function RightSidebar({
-  tables = [],
-  ...props
-}: {
-  tables: TableType[]
-}) {
+export default function RightSidebar() {
+  const tables = useTables()
+
   return (
     <Sidebar
       collapsible="none"
       className="sticky top-0 hidden h-svh max-w-[35vw] border-l lg:flex"
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...props}
       side="right"
     >
       <SidebarHeader className="gap-3.5 border-b p-4">
@@ -30,13 +26,17 @@ export default function RightSidebar({
           </div>
         </div>
       </SidebarHeader>
-      <SidebarContent>
-        <SidebarGroup className="p-0">
-          <SidebarGroupContent>
-            <ViewTable tableData={tables} />
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
+      {tables.isLoading ? (
+        <LoadingPage />
+      ) : (
+        <SidebarContent>
+          <SidebarGroup className="p-0">
+            <SidebarGroupContent>
+              <ViewTable tableData={tables.data || []} />
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+      )}
     </Sidebar>
   )
 }

--- a/FE/src/pages/LoadingPage.tsx
+++ b/FE/src/pages/LoadingPage.tsx
@@ -1,0 +1,10 @@
+export default function LoadingPage() {
+  return (
+    <div className="flex h-full min-h-[80vh] min-w-[25vw] flex-col items-center justify-center border-l">
+      <div className="mb-4 flex items-center justify-center">
+        <span className="h-10 w-10 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
+      </div>
+      <p className="text-lg font-semibold text-gray-700">Loading...</p>
+    </div>
+  )
+}

--- a/FE/src/pages/MainPage.tsx
+++ b/FE/src/pages/MainPage.tsx
@@ -6,13 +6,11 @@ import RightSidebar from '@/components/RightSidebar'
 import { Toaster } from '@/components/ui/toaster'
 import MainContent from '@/components/MainContent'
 
-import { useTables } from '@/hooks/query/useTableQuery'
 import { ErrorBoundary } from 'react-error-boundary'
 import MainErrorPage from './MainErrorPage'
 
 export default function MainPage() {
   const [activeItem, setActiveItem] = useState(MENU[0])
-  const tables = useTables()
 
   return (
     <SidebarProvider
@@ -26,15 +24,11 @@ export default function MainPage() {
         FallbackComponent={MainErrorPage}
         onReset={() => window.location.reload()}
       >
-        <LeftSidebar
-          activeItem={activeItem}
-          setActiveItem={setActiveItem}
-          tables={tables.data || []}
-        />
+        <LeftSidebar activeItem={activeItem} setActiveItem={setActiveItem} />
         <SidebarInset>
           <MainContent />
         </SidebarInset>
-        <RightSidebar tables={tables.data || []} />
+        <RightSidebar />
         <Toaster />
       </ErrorBoundary>
     </SidebarProvider>

--- a/FE/tailwind.config.js
+++ b/FE/tailwind.config.js
@@ -69,6 +69,9 @@ export default {
           border: 'hsl(var(--sidebar-border))',
           ring: 'hsl(var(--sidebar-ring))',
         },
+        animation: {
+          'spin-slow': 'spin 3s linear infinite',
+        },
       },
     },
   },


### PR DESCRIPTION
## 📝 기능 설명
로딩페이지를 추가하였습니다.

<br>

## 🛠 핵심 작업 사항
- 로딩페이지 구현
- 로딩 로직 추가

<br>

## 🤔 기타
- 메인 페이지에서 프롭으로 넘기던 useTable데이터를 각 사이드바에 부여
   - `useTables`의 API 요청이 두 번 발생하지만 **React Query** 캐싱으로 인해 불필요한 네트워크 요청이 방지됩니다.

<br>

## 📎 참고 자료
![화면 기록 2024-12-03 오후 2 05 57](https://github.com/user-attachments/assets/f66a0426-cf09-49ba-81a3-75353705c48f)
