### PR TITLE
[#249] LOAD DATA 분산처리

### DIFF
--- a/BE/src/record/constant/random-record.constant.ts
+++ b/BE/src/record/constant/random-record.constant.ts
@@ -9,7 +9,7 @@ import {
 } from '../domain';
 
 export const RANDOM_DATA_TEMP_DIR = 'csvTemp';
-export const RECORD_PROCESS_BATCH_SIZE = 10000;
+export const RECORD_PROCESS_BATCH_SIZE = 100000;
 
 export const generalDomain = [
   'name',

--- a/BE/src/record/file.service.ts
+++ b/BE/src/record/file.service.ts
@@ -38,6 +38,7 @@ export class FileService implements OnModuleInit {
     const filePaths: string[] = [];
     let remainRows = rows;
     let batchIndex = 0;
+    const header = this.generateCsvHeader(columnEntities);
 
     while (remainRows > 0) {
       const currentBatchSize = Math.min(remainRows, RECORD_PROCESS_BATCH_SIZE);
@@ -46,8 +47,6 @@ export class FileService implements OnModuleInit {
         RANDOM_DATA_TEMP_DIR,
         `${randomString}_${batchIndex}.csv`,
       );
-      const header = this.generateCsvHeader(columnEntities);
-
       try {
         await fs.writeFile(filePath, header + '\n' + data);
       } catch (err) {
@@ -57,7 +56,6 @@ export class FileService implements OnModuleInit {
           error: err.message,
         });
       }
-
       filePaths.push(filePath);
       remainRows -= currentBatchSize;
       batchIndex++;

--- a/BE/src/record/record.service.ts
+++ b/BE/src/record/record.service.ts
@@ -74,25 +74,27 @@ export class RecordService {
       createRandomRecordDto.columns.map((column) => this.toEntity(column));
     const columnNames = columnEntities.map((column) => column.name);
 
-    const csvFilePath = await this.fileService.generateCsvFile(
+    const csvFilePaths = await this.fileService.generateCsvFile(
       columnEntities,
       createRandomRecordDto.count,
     );
 
-    const result = await this.fileService.insertCsvIntoDB(
+    const affectedRows = await this.fileService.loadCSVFilesToDB(
       req,
-      csvFilePath,
+      csvFilePaths,
       createRandomRecordDto.tableName,
       columnNames,
     );
 
-    await this.fileService.deleteFile(csvFilePath);
+    for (const csvFilepath of csvFilePaths) {
+      this.fileService.deleteFile(csvFilepath);
+    }
 
     await this.usageService.updateRowCount(req);
 
     return new ResRecordDto({
-      status: result.affectedRows === createRandomRecordDto.count,
-      text: `${createRandomRecordDto.tableName} 에 랜덤 레코드 ${result.affectedRows}개 삽입되었습니다.`,
+      status: affectedRows === createRandomRecordDto.count,
+      text: `${createRandomRecordDto.tableName} 에 랜덤 레코드 ${affectedRows}개 삽입되었습니다.`,
     });
   }
 


### PR DESCRIPTION
## 📝 기능 설명
LOAD DATA로 모든 파일을 한번에 삽입하면 한 스레드 밖에 사용못하여 대용량의 데이터 삽입시 느려질 수 있다.  
파일 배치작업을 여러개 파일로 생성하는것으로 바꾸고 이를 각각 삽입하도록 변경

## 🛠 작업 사항
- 배치사이즈 크기 10만으로 수정  
- 기존 배치작업으로 파일 write 하는 것을 다른 파일에 작성하도록 변경
- 각 파일에 대하여 LOADDATA 실행

## ✅ 작업 체크리스트
- [x] LOAD DATA 분산처리

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->
